### PR TITLE
DeepSeek-V4-Flash enablement layer for DGX Spark (GB10/sm_121a), TP2

### DIFF
--- a/Dockerfile.deepseek-v4-gb10-layer
+++ b/Dockerfile.deepseek-v4-gb10-layer
@@ -1,0 +1,64 @@
+# aeon-vllm-ultimate + DeepSeek-V4-Flash enablement for DGX Spark (GB10 / sm_121a).
+#
+# The 0.24 base already ships the native vllm/models/deepseek_v4 package, but on GB10 its
+# fp8 compute path dies on a cascade of gaps (all validated on 2x DGX Spark, TP2 over RoCE):
+#   1. nvidia-cutlass-dsl 4.6.0 removed cute.core.ThrMma, which the base's own
+#      deepseek_v4/nvidia/ops/fused_indexer_q_cutedsl.py still annotates -> AttributeError
+#      on ANY DeepSeek-V4 load (even on datacenter GPUs). Pin 4.5.2.
+#   2. The vendored DeepGEMM has no sm_12x kernels (fp8_einsum / tf32_hc_prenorm_gemm /
+#      paged mqa logits all assert "Unsupported architecture"). Install DeepGEMM nv_dev
+#      (deepseek-ai/DeepGEMM#324: native sm120 CuTeDSL kernels) into site-packages, which
+#      vllm.utils.deep_gemm prefers over the vendored copy.
+#   3. flashinfer 0.6.12 lacks the swa_topk_lens / extra_sparse_* sparse-MLA decode API that
+#      the base's deepseek_v4/nvidia/flashinfer_sparse.py calls. Upgrade to 0.6.14.
+#   4. Three thin .py overlays (see overlay-deepseek-v4-gb10/):
+#      - o_proj.py: nv_dev fp8_einsum expects unpacked fp32 scales + (h,d,r) weights; adapt
+#        the SM100 packed-ue8m0 layout on sm12x.
+#      - sparse_attn_indexer.py: cooperative_topk's cluster launch fails on GB10
+#        ("invalid argument"); gate sm12x to the existing persistent_topk path.
+#      - scaled_mm/triton.py: cast E8M0 scale tensors to fp32 before the triton block-scaled
+#        MM (triton's JIT has no float8_e8m0fnu mapping; the cast is exact).
+#
+# Serve notes (2-node TP2): --moe-backend marlin --linear-backend triton,
+# VLLM_DEEP_GEMM_WARMUP=skip (the linear warmup pass feeds raw e8m0 scales to fp8_gemm_nt),
+# cudagraph_mode PIECEWISE (FULL decode graphs hang on GB10, cf. vllm#40969).
+FROM ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-01-v0.24.0
+LABEL aeon.layer="deepseek-v4-gb10" \
+      aeon.base="2026-07-01-v0.24.0" \
+      aeon.fixes="cutlass-dsl-4.5.2-thrmma,deepgemm-nv_dev-sm120,flashinfer-0.6.14-sparse-mla,o_proj-sm12x-adapter,persistent-topk-sm12x,triton-e8m0-upcast"
+
+# (1) cutlass-dsl: 4.6.0 dropped cute.core.ThrMma which the base's cutedsl ops use.
+RUN pip uninstall -y nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-cu12 || true
+RUN pip install --no-cache-dir nvidia-cutlass-dsl==4.5.2 && \
+    python3 -c "import cutlass.cute.core as c; assert hasattr(c, 'ThrMma'); print('cutlass-dsl 4.5.2: ThrMma OK')"
+
+# (2) DeepGEMM nv_dev (sm120 kernels; deepseek-ai/DeepGEMM#324). Pinned commit.
+ENV TORCH_CUDA_ARCH_LIST=12.1a
+RUN git clone https://github.com/deepseek-ai/DeepGEMM.git /opt/deepgemm && \
+    cd /opt/deepgemm && git checkout a6b593d && git submodule update --init --recursive && \
+    MAX_JOBS=8 pip install --no-build-isolation --no-deps -v . 2>&1 | tail -4
+# import check in its own RUN: cwd must not be /opt/deepgemm, or python imports the source tree
+# instead of site-packages ("cannot import name '_C' ... circular import").
+RUN cd / && python3 -c "import deep_gemm; syms=[s for s in ('fp8_einsum','tf32_hc_prenorm_gemm','get_paged_mqa_logits_metadata','fp8_paged_mqa_logits') if hasattr(deep_gemm, s)]; assert len(syms) >= 3, syms; print('deep_gemm nv_dev OK:', syms)"
+
+# (3) flashinfer 0.6.14 (swa_topk_lens sparse-MLA API the base's flashinfer_sparse.py targets).
+RUN pip install --no-cache-dir --no-deps \
+      https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_python-0.6.14-py3-none-any.whl \
+      https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_cubin-0.6.14-py3-none-any.whl \
+      https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu130-cp39-abi3-manylinux_2_28_aarch64.whl && \
+    python3 -c "import flashinfer, inspect; from flashinfer.mla import _core; assert 'swa_topk_lens' in inspect.signature(_core.trtllm_batch_decode_sparse_mla_dsv4).parameters; print('flashinfer', flashinfer.__version__, 'sparse-MLA API OK')"
+
+# (4) thin .py overlays (sm12x-gated; no behavior change on sm90/sm100).
+COPY overlay-deepseek-v4-gb10/vllm/ /usr/local/lib/python3.12/site-packages/vllm/
+
+# Smoke: the exact import that breaks on the unpatched base.
+RUN python3 -c "\
+import vllm.models.deepseek_v4 as m; \
+import vllm.models.deepseek_v4.nvidia.ops.o_proj as o; \
+import inspect; src = inspect.getsource(o); \
+assert '_sm12x' in src, 'o_proj sm12x adapter missing'; \
+import vllm.model_executor.layers.sparse_attn_indexer as s; \
+ssrc = inspect.getsource(s); \
+assert 'has_device_capability(120)' in ssrc, 'persistent_topk gate missing'; \
+print('deepseek-v4-gb10 overlay smoke: OK')"
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile.deepseek-v4-gb10-layer
+++ b/Dockerfile.deepseek-v4-gb10-layer
@@ -1,44 +1,48 @@
 # aeon-vllm-ultimate + DeepSeek-V4-Flash enablement for DGX Spark (GB10 / sm_121a).
 #
-# The 0.24 base already ships the native vllm/models/deepseek_v4 package, but on GB10 its
-# fp8 compute path dies on a cascade of gaps (all validated on 2x DGX Spark, TP2 over RoCE):
-#   1. nvidia-cutlass-dsl 4.6.0 removed cute.core.ThrMma, which the base's own
-#      deepseek_v4/nvidia/ops/fused_indexer_q_cutedsl.py still annotates -> AttributeError
-#      on ANY DeepSeek-V4 load (even on datacenter GPUs). Pin 4.5.2.
-#   2. The vendored DeepGEMM has no sm_12x kernels (fp8_einsum / tf32_hc_prenorm_gemm /
-#      paged mqa logits all assert "Unsupported architecture"). Install DeepGEMM nv_dev
-#      (deepseek-ai/DeepGEMM#324: native sm120 CuTeDSL kernels) into site-packages, which
-#      vllm.utils.deep_gemm prefers over the vendored copy.
-#   3. flashinfer 0.6.12 lacks the swa_topk_lens / extra_sparse_* sparse-MLA decode API that
-#      the base's deepseek_v4/nvidia/flashinfer_sparse.py calls. Upgrade to 0.6.14.
-#   4. Three thin .py overlays (see overlay-deepseek-v4-gb10/):
-#      - o_proj.py: nv_dev fp8_einsum expects unpacked fp32 scales + (h,d,r) weights; adapt
-#        the SM100 packed-ue8m0 layout on sm12x.
-#      - sparse_attn_indexer.py: cooperative_topk's cluster launch fails on GB10
-#        ("invalid argument"); gate sm12x to the existing persistent_topk path.
-#      - scaled_mm/triton.py: cast E8M0 scale tensors to fp32 before the triton block-scaled
-#        MM (triton's JIT has no float8_e8m0fnu mapping; the cast is exact).
+# The 0.24 base ships the native vllm/models/deepseek_v4 package but cannot serve it on GB10.
+# This layer fixes the full cascade, keeping the base's stock nvidia-cutlass-dsl 4.6.0
+# (validated end-to-end on 2x DGX Spark, TP2 + expert-parallel over RoCE):
+#   1. cutlass-dsl 4.6.0 moved ThrMma/TiledMma from cutlass.cute.core to the cutlass.cute top
+#      level; the base's own deepseek_v4 cutedsl ops (and vllm_flash_attn/cute) still reference
+#      cute.core.ThrMma -> AttributeError on ANY DeepSeek-V4 load. Fix: a PEP-562 lazy
+#      re-export shim appended to cute/core.py (thrmma_shim.py).
+#   2. The vendored DeepGEMM has no sm_12x kernels. Install DeepGEMM nv_dev (deepseek-ai/
+#      DeepGEMM#324: native sm120 kernels); site-packages takes precedence over the vendored copy.
+#   3. flashinfer 0.6.12 lacks the swa_topk_lens sparse-MLA decode API the base's
+#      flashinfer_sparse.py calls. Upgrade the trio to 0.6.14.
+#   4. cutlass 4.6.0's tvm-ffi AOT provider needs make_kwargs_wrapper(map_dataclass_to_tuple=...)
+#      -> apache-tvm-ffi >= 0.1.10; but tvm-ffi 0.1.12 aborts tilelang (double type-attr
+#      registration). The working pair: apache-tvm-ffi 0.1.11 + tilelang 0.1.11.
+#   5. Thin .py overlays (sm12x-gated or version-agnostic; no behavior change on sm90/100):
+#      - o_proj.py: adapt the SM100 packed-ue8m0 layout to nv_dev's fp8_einsum API
+#      - sparse_attn_indexer.py: route sm12x to persistent_topk (cooperative cluster launch
+#        fails on GB10)
+#      - scaled_mm/triton.py: exact e8m0->fp32 scale upcast (triton JIT has no E8M0 dtype)
+#      - vllm_flash_attn/cute/utils.py: pick the nvvm.fmax binding by signature feature-
+#        detection instead of the CUDA_VERSION proxy (4.6.0 reports CUDA 12.9 but ships the
+#        new bindings)
 #
-# Serve notes (2-node TP2): --moe-backend marlin --linear-backend triton,
-# VLLM_DEEP_GEMM_WARMUP=skip (the linear warmup pass feeds raw e8m0 scales to fp8_gemm_nt),
-# cudagraph_mode PIECEWISE (FULL decode graphs hang on GB10, cf. vllm#40969).
+# Serve notes: --moe-backend marlin --linear-backend triton, VLLM_DEEP_GEMM_WARMUP=skip,
+# cudagraph_mode PIECEWISE + --max-num-seqs 8 (FULL decode-graph replay of any capture size
+# desyncs NCCL between the two ranks -> DistBackendError; collectives must stay uncaptured).
 FROM ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-01-v0.24.0
 LABEL aeon.layer="deepseek-v4-gb10" \
       aeon.base="2026-07-01-v0.24.0" \
-      aeon.fixes="cutlass-dsl-4.5.2-thrmma,deepgemm-nv_dev-sm120,flashinfer-0.6.14-sparse-mla,o_proj-sm12x-adapter,persistent-topk-sm12x,triton-e8m0-upcast"
+      aeon.fixes="thrmma-core-shim,deepgemm-nv_dev-sm120,flashinfer-0.6.14-sparse-mla,tvmffi-0.1.11-tilelang-0.1.11,o_proj-sm12x-adapter,persistent-topk-sm12x,triton-e8m0-upcast,nvvm-fmax-feature-detect"
 
-# (1) cutlass-dsl: 4.6.0 dropped cute.core.ThrMma which the base's cutedsl ops use.
-RUN pip uninstall -y nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-cu12 || true
-RUN pip install --no-cache-dir nvidia-cutlass-dsl==4.5.2 && \
-    python3 -c "import cutlass.cute.core as c; assert hasattr(c, 'ThrMma'); print('cutlass-dsl 4.5.2: ThrMma OK')"
+# (1) re-export the classes cutlass-dsl 4.6.0 relocated out of cute.core (PEP 562, lazy).
+COPY thrmma_shim.py /tmp/thrmma_shim.py
+RUN CORE=$(python3 -c "import cutlass.cute.core as c; print(c.__file__)") && \
+    cat /tmp/thrmma_shim.py >> "$CORE" && rm /tmp/thrmma_shim.py && \
+    python3 -c "import cutlass.cute.core as c; assert c.ThrMma is not None and c.TiledMma is not None; import cutlass; print('cutlass', cutlass.__version__, 'ThrMma shim OK')"
 
 # (2) DeepGEMM nv_dev (sm120 kernels; deepseek-ai/DeepGEMM#324). Pinned commit.
 ENV TORCH_CUDA_ARCH_LIST=12.1a
 RUN git clone https://github.com/deepseek-ai/DeepGEMM.git /opt/deepgemm && \
     cd /opt/deepgemm && git checkout a6b593d && git submodule update --init --recursive && \
     MAX_JOBS=8 pip install --no-build-isolation --no-deps -v . 2>&1 | tail -4
-# import check in its own RUN: cwd must not be /opt/deepgemm, or python imports the source tree
-# instead of site-packages ("cannot import name '_C' ... circular import").
+# import check in its own RUN: cwd must not be /opt/deepgemm, or python imports the source tree.
 RUN cd / && python3 -c "import deep_gemm; syms=[s for s in ('fp8_einsum','tf32_hc_prenorm_gemm','get_paged_mqa_logits_metadata','fp8_paged_mqa_logits') if hasattr(deep_gemm, s)]; assert len(syms) >= 3, syms; print('deep_gemm nv_dev OK:', syms)"
 
 # (3) flashinfer 0.6.14 (swa_topk_lens sparse-MLA API the base's flashinfer_sparse.py targets).
@@ -48,17 +52,21 @@ RUN pip install --no-cache-dir --no-deps \
       https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.14/flashinfer_jit_cache-0.6.14+cu130-cp39-abi3-manylinux_2_28_aarch64.whl && \
     python3 -c "import flashinfer, inspect; from flashinfer.mla import _core; assert 'swa_topk_lens' in inspect.signature(_core.trtllm_batch_decode_sparse_mla_dsv4).parameters; print('flashinfer', flashinfer.__version__, 'sparse-MLA API OK')"
 
-# (4) thin .py overlays (sm12x-gated; no behavior change on sm90/sm100).
+# (4) cutlass 4.6.0's tvm-ffi AOT provider needs >=0.1.10; 0.1.12 breaks tilelang.
+RUN pip install --no-cache-dir --no-deps apache-tvm-ffi==0.1.11 tilelang==0.1.11 && \
+    python3 -c "import inspect; from tvm_ffi.utils.kwargs_wrapper import make_kwargs_wrapper; assert 'map_dataclass_to_tuple' in inspect.signature(make_kwargs_wrapper).parameters; import tilelang, tvm_ffi; print('tvm-ffi 0.1.11 + tilelang', tilelang.__version__, 'OK')"
+
+# (5) thin .py overlays.
 COPY overlay-deepseek-v4-gb10/vllm/ /usr/local/lib/python3.12/site-packages/vllm/
 
-# Smoke: the exact import that breaks on the unpatched base.
+# Smoke: the exact imports that break on the unpatched base.
 RUN python3 -c "\
 import vllm.models.deepseek_v4 as m; \
 import vllm.models.deepseek_v4.nvidia.ops.o_proj as o; \
-import inspect; src = inspect.getsource(o); \
-assert '_sm12x' in src, 'o_proj sm12x adapter missing'; \
+import inspect; assert '_sm12x' in inspect.getsource(o); \
 import vllm.model_executor.layers.sparse_attn_indexer as s; \
-ssrc = inspect.getsource(s); \
-assert 'has_device_capability(120)' in ssrc, 'persistent_topk gate missing'; \
+assert 'has_device_capability(120)' in inspect.getsource(s); \
+import vllm.vllm_flash_attn.cute.utils as u; \
+assert '_nvvm_params' in inspect.getsource(u); \
 print('deepseek-v4-gb10 overlay smoke: OK')"
 ENTRYPOINT ["/bin/bash"]

--- a/README-DEEPSEEK-V4-GB10.md
+++ b/README-DEEPSEEK-V4-GB10.md
@@ -1,17 +1,21 @@
 # DeepSeek-V4-Flash on 2× DGX Spark (GB10 / sm_121a) — TP2 enablement layer
 
 `Dockerfile.deepseek-v4-gb10-layer` makes the stock `aeon-vllm-ultimate:2026-07-01-v0.24.0`
-image serve **DeepSeek-V4-Flash** across two DGX Sparks (TP=2, expert-parallel, RoCE).
-The base already ships the native `vllm/models/deepseek_v4` package; on GB10 it dies on a
-cascade of five gaps, each fixed here (validated end-to-end on 2× DGX Spark):
+image serve **DeepSeek-V4-Flash** across two DGX Sparks (TP=2, expert-parallel, RoCE), keeping
+the base's stock **nvidia-cutlass-dsl 4.6.0**. The base already ships the native
+`vllm/models/deepseek_v4` package; on GB10 it dies on a cascade of gaps, each fixed here
+(validated end-to-end on 2× DGX Spark; **66.4 tok/s aggregate** over 10 concurrent multi-turn
+conversations, full benchmark with zero engine errors):
 
 | # | Symptom on stock 0.24 (GB10) | Root cause | Fix in this layer |
 |---|---|---|---|
-| 1 | `AttributeError: cutlass.cute.core has no attribute 'ThrMma'` on **any** DeepSeek-V4 load | image ships `nvidia-cutlass-dsl 4.6.0`, which removed `ThrMma`; the base's own `deepseek_v4/nvidia/ops/fused_indexer_q_cutedsl.py` still uses it | pin `nvidia-cutlass-dsl==4.5.2` |
-| 2 | DeepGEMM asserts `Unsupported architecture` (`hyperconnection.hpp`, `attention.hpp`, einsum `layout.hpp`) | vendored DeepGEMM has sm90/sm100 kernels only | install DeepGEMM `nv_dev` @ `a6b593d` ([deepseek-ai/DeepGEMM#324](https://github.com/deepseek-ai/DeepGEMM/pull/324): native sm120 kernels); site-packages takes precedence over the vendored copy |
-| 3 | `trtllm_batch_decode_sparse_mla_dsv4() got an unexpected keyword 'swa_topk_lens'` | the base's `flashinfer_sparse.py` targets the 0.6.14 sparse-MLA API; image ships flashinfer 0.6.12 | upgrade flashinfer trio to 0.6.14 (python+cubin+jit-cache cu130/aarch64) |
-| 4 | nv_dev `fp8_einsum` asserts `t.dim() == N`; `cooperative_topk launch failed: invalid argument`; triton `KeyError: 'float8_e8m0fnu'` | o_proj passes SM100 packed-ue8m0 layout; cooperative topk needs cluster launch GB10 lacks; triton JIT has no E8M0 dtype | three thin `.py` overlays, all gated to sm12x (no change on sm90/100): o_proj scale/shape adapter → nv_dev API; route sm12x to the existing `persistent_topk`; exact e8m0→fp32 scale upcast |
-| 5 | `deep_gemm_warmup` asserts `sfb_dtype == kFloat or kInt`; batched long-context decode hangs (`sample_tokens` RPC timeout) under every cudagraph mode | linear warmup feeds raw e8m0 scales to `fp8_gemm_nt`; graph-replay + sparse-MLA decode wedge on GB10 (cf. [vllm#40969](https://github.com/vllm-project/vllm/issues/40969); see Known issue below) | serve flags: `VLLM_DEEP_GEMM_WARMUP=skip`, `--enforce-eager`, `--max-num-seqs 2` |
+| 1 | `AttributeError: cutlass.cute.core has no attribute 'ThrMma'` on **any** DeepSeek-V4 load | cutlass-dsl 4.6.0 moved `ThrMma`/`TiledMma` from `cute.core` to the `cutlass.cute` top level; the base's own cutedsl ops still use the old path | `thrmma_shim.py`: PEP-562 lazy re-export appended to `cute/core.py` |
+| 2 | DeepGEMM asserts `Unsupported architecture` (`hyperconnection.hpp`, `attention.hpp`, einsum `layout.hpp`) | vendored DeepGEMM has sm90/sm100 kernels only | install DeepGEMM `nv_dev` @ `a6b593d` ([deepseek-ai/DeepGEMM#324](https://github.com/deepseek-ai/DeepGEMM/pull/324): native sm120 kernels); site-packages takes precedence |
+| 3 | `trtllm_batch_decode_sparse_mla_dsv4() got an unexpected keyword 'swa_topk_lens'` | the base's `flashinfer_sparse.py` targets the 0.6.14 sparse-MLA API; image ships 0.6.12 | upgrade flashinfer trio to 0.6.14 (python+cubin+jit-cache cu130/aarch64) |
+| 4 | `make_kwargs_wrapper() got an unexpected keyword argument 'map_dataclass_to_tuple'` at first cutedsl AOT compile | cutlass 4.6.0's tvm-ffi provider needs apache-tvm-ffi ≥0.1.10 (base ships 0.1.9); but 0.1.12 aborts tilelang (`TypeAttr __ffi_repr__ already registered`) | the working pair: **apache-tvm-ffi 0.1.11 + tilelang 0.1.11** |
+| 5 | `fmax() takes 2 positional arguments but 3 ... given` in cutedsl kernels | `vllm_flash_attn/cute/utils.py` picks the nvvm.fmax binding by `CUDA_VERSION`, and cutlass-dsl 4.6.0 reports CUDA 12.9 while shipping the new bindings | overlay: feature-detect the binding signature instead of the version proxy |
+| 6 | nv_dev `fp8_einsum` asserts `t.dim() == N`; `cooperative_topk launch failed: invalid argument`; triton `KeyError: 'float8_e8m0fnu'` | o_proj passes SM100 packed-ue8m0 layout; cooperative topk needs cluster launch GB10 lacks; triton JIT has no E8M0 dtype | three sm12x-gated overlays: o_proj scale/shape adapter → nv_dev API; route sm12x to the existing `persistent_topk`; exact e8m0→fp32 upcast |
+| 7 | `deep_gemm_warmup` asserts `sfb_dtype == kFloat or kInt` | the linear warmup pass feeds raw e8m0 scales to `fp8_gemm_nt` | serve flag `VLLM_DEEP_GEMM_WARMUP=skip` |
 
 ## Build
 
@@ -46,38 +50,36 @@ docker run -d --name vllm-ds4 --runtime nvidia --gpus all --ipc host --network h
   --distributed-executor-backend mp --nnodes 2 --node-rank 0 \
   --master-addr <head-fabric-ip> --master-port 29519 \
   --kv-cache-dtype fp8 --block-size 256 --enable-prefix-caching \
-  --max-model-len 65536 --max-num-seqs 2 --max-num-batched-tokens 4096 \
+  --max-model-len 65536 --max-num-seqs 8 --max-num-batched-tokens 4096 \
   --gpu-memory-utilization 0.80 --no-enable-flashinfer-autotune \
-  --enforce-eager \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE","custom_ops":["all"]}' \
   --reasoning-parser deepseek_v4 --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
   --load-format safetensors --host 0.0.0.0 --port 8000
 ```
 
 Notes:
 - **First cold start JIT-compiles flashinfer 0.6.14 kernels (~20 min).** Launch both ranks
-  together only after the cache is warm, or rank 1's Gloo barrier can time out
-  (`Application timeout caused pair closure`). Persist `/root/.cache/flashinfer`.
+  together only after the cache is warm, or rank 1's Gloo barrier can time out. Persist
+  `/root/.cache/flashinfer` and `/root/.triton`.
 - `--moe-backend marlin` covers the MXFP4/fp8 expert checkpoints; `--linear-backend triton`
   covers the E8M0 fp8 linears (with the overlay upcast).
 - `NCCL 2.28.9` in the base works cross-node over RoCE as-is (no LD_PRELOAD needed).
-- **Known issue — batched long-context decode wedges the engine; run `--enforce-eager`
-  and `--max-num-seqs 2`.** With any cudagraph mode (FULL, PIECEWISE, or the base's
-  auto-enabled breakable-cudagraph) the workers go silent during batched decode once
-  accumulated contexts grow past a few thousand tokens; `sample_tokens` RPC times out and
-  the engine dies. `VLLM_USE_BREAKABLE_CUDAGRAPH=0` extends survival ~6× and eager mode +
-  `max_num_seqs 2` is fully stable (complete 12-category multi-turn benchmark, 48/48 turns,
-  zero engine errors). Suspect: sparse-MLA decode path (nv_dev paged-MQA / persistent_topk /
-  flashinfer trtllm sparse) at batch>2 with long contexts — needs kernel-level investigation.
-  `VLLM_RPC_TIMEOUT=3600000` + `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3600` are belt-and-braces
-  for first-contact Triton JIT spikes; persist `/root/.triton` so those compile only once.
+- **Known issue — FULL decode-graph replay desyncs NCCL between the two ranks.** Any
+  configuration that replays FULL decode graphs (`FULL_AND_PIECEWISE` at default capture
+  sizes, with breakable-cudagraph on or off, or even restricted `cudagraph_capture_sizes:
+  [1,2]`) dies under batched long-context decode with rank 1 `c10::DistBackendError`
+  ("Some NCCL operations have failed or timed out"). Collectives must stay uncaptured on
+  this 2-node TP2 fabric: **`cudagraph_mode: PIECEWISE` is fully stable** (2×10 concurrent
+  9K-context generations + a complete 12-category multi-turn benchmark, zero engine errors)
+  and is what the numbers below were measured with.
 
-## Validation (2× DGX Spark GB10, DeepSeek-V4-Flash-DSpark fp8)
+## Validation (2× DGX Spark GB10, DeepSeek-V4-Flash-DSpark fp8, PIECEWISE + seqs 8)
 
-- Engine init 58 s (warm cache); GPU KV cache **782,838 tokens** (gpu_mem_util 0.80).
-- Numerically sane at temp 0 (exact-arithmetic + factual probes match a known-good
-  independent GB10 build within phrasing variance); coherent long-form generation; a full
-  12-category multi-turn benchmark graded at quality parity with that independent build.
-- Final config (eager, max_num_seqs 2): **complete benchmark run with zero engine errors —
-  48/48 turns**, single-stream decode **17.8 tok/s** (TTFT ~2.8 s), **28.6 tok/s aggregate**
-  across 10 concurrent multi-turn categories.
-- 2×10 concurrent 1500-token generations: 20/20 HTTP 200, engine alive.
+- **Aggregate 66.4 tok/s** over 10 concurrent multi-turn conversations; single-stream
+  16.6 tok/s; **48/48 benchmark turns, zero engine errors**.
+- Engine init ~58 s (warm cache); GPU KV cache 782,838 tokens at util 0.80.
+- Output quality graded at parity with an independent jasl-fork GB10 build of the same
+  checkpoint (no garbling; temp-0 arithmetic/factual probes consistent).
+- Stability: 4× and 10× concurrent 9K-context/800-token generations pass under eager and
+  PIECEWISE; the batch>2 long-context deadlock present with the 4.5.x-era dependency set
+  is fixed by the tvm-ffi 0.1.11 AOT-recompiled cutedsl kernels.

--- a/README-DEEPSEEK-V4-GB10.md
+++ b/README-DEEPSEEK-V4-GB10.md
@@ -1,0 +1,83 @@
+# DeepSeek-V4-Flash on 2× DGX Spark (GB10 / sm_121a) — TP2 enablement layer
+
+`Dockerfile.deepseek-v4-gb10-layer` makes the stock `aeon-vllm-ultimate:2026-07-01-v0.24.0`
+image serve **DeepSeek-V4-Flash** across two DGX Sparks (TP=2, expert-parallel, RoCE).
+The base already ships the native `vllm/models/deepseek_v4` package; on GB10 it dies on a
+cascade of five gaps, each fixed here (validated end-to-end on 2× DGX Spark):
+
+| # | Symptom on stock 0.24 (GB10) | Root cause | Fix in this layer |
+|---|---|---|---|
+| 1 | `AttributeError: cutlass.cute.core has no attribute 'ThrMma'` on **any** DeepSeek-V4 load | image ships `nvidia-cutlass-dsl 4.6.0`, which removed `ThrMma`; the base's own `deepseek_v4/nvidia/ops/fused_indexer_q_cutedsl.py` still uses it | pin `nvidia-cutlass-dsl==4.5.2` |
+| 2 | DeepGEMM asserts `Unsupported architecture` (`hyperconnection.hpp`, `attention.hpp`, einsum `layout.hpp`) | vendored DeepGEMM has sm90/sm100 kernels only | install DeepGEMM `nv_dev` @ `a6b593d` ([deepseek-ai/DeepGEMM#324](https://github.com/deepseek-ai/DeepGEMM/pull/324): native sm120 kernels); site-packages takes precedence over the vendored copy |
+| 3 | `trtllm_batch_decode_sparse_mla_dsv4() got an unexpected keyword 'swa_topk_lens'` | the base's `flashinfer_sparse.py` targets the 0.6.14 sparse-MLA API; image ships flashinfer 0.6.12 | upgrade flashinfer trio to 0.6.14 (python+cubin+jit-cache cu130/aarch64) |
+| 4 | nv_dev `fp8_einsum` asserts `t.dim() == N`; `cooperative_topk launch failed: invalid argument`; triton `KeyError: 'float8_e8m0fnu'` | o_proj passes SM100 packed-ue8m0 layout; cooperative topk needs cluster launch GB10 lacks; triton JIT has no E8M0 dtype | three thin `.py` overlays, all gated to sm12x (no change on sm90/100): o_proj scale/shape adapter → nv_dev API; route sm12x to the existing `persistent_topk`; exact e8m0→fp32 scale upcast |
+| 5 | `deep_gemm_warmup` asserts `sfb_dtype == kFloat or kInt`; batched long-context decode hangs (`sample_tokens` RPC timeout) under every cudagraph mode | linear warmup feeds raw e8m0 scales to `fp8_gemm_nt`; graph-replay + sparse-MLA decode wedge on GB10 (cf. [vllm#40969](https://github.com/vllm-project/vllm/issues/40969); see Known issue below) | serve flags: `VLLM_DEEP_GEMM_WARMUP=skip`, `--enforce-eager`, `--max-num-seqs 2` |
+
+## Build
+
+```bash
+docker build -t aeon-vllm-ultimate:deepseek-v4-gb10 -f Dockerfile.deepseek-v4-gb10-layer .
+```
+
+## Serve (2 nodes, TP2 + EP over RoCE)
+
+Head (rank 0) — swap in your fabric IPs/ifaces; worker (rank 1) is identical plus `--headless`
+and `--node-rank 1`:
+
+```bash
+docker run -d --name vllm-ds4 --runtime nvidia --gpus all --ipc host --network host \
+  --shm-size 16g --cap-add=SYS_PTRACE --cap-add=IPC_LOCK --ulimit memlock=-1:-1 \
+  --device=/dev/infiniband \
+  -v /path/to/models:/models -v /path/to/flashinfer-cache:/root/.cache/flashinfer \
+  -v /path/to/triton-cache:/root/.triton \
+  -e VLLM_HOST_IP=<this-node-fabric-ip> \
+  -e NCCL_IB_HCA=<roce-hca> -e NCCL_IB_GID_INDEX=3 -e NCCL_IB_DISABLE=0 \
+  -e NCCL_SOCKET_IFNAME=<fabric-if> -e GLOO_SOCKET_IFNAME=<fabric-if> \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True -e TORCH_CUDA_ARCH_LIST=12.1a \
+  -e VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
+  -e VLLM_DEEP_GEMM_WARMUP=skip \
+  -e VLLM_RPC_TIMEOUT=3600000 -e TRITON_CACHE_DIR=/root/.triton \
+  -e VLLM_USE_BREAKABLE_CUDAGRAPH=0 -e VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3600 \
+  --entrypoint vllm aeon-vllm-ultimate:deepseek-v4-gb10 \
+  serve /models/deepseek-ai/DeepSeek-V4-Flash \
+  --served-model-name DeepSeek-V4-Flash --trust-remote-code --tokenizer-mode deepseek_v4 \
+  --tensor-parallel-size 2 --enable-expert-parallel \
+  --moe-backend marlin --linear-backend triton \
+  --distributed-executor-backend mp --nnodes 2 --node-rank 0 \
+  --master-addr <head-fabric-ip> --master-port 29519 \
+  --kv-cache-dtype fp8 --block-size 256 --enable-prefix-caching \
+  --max-model-len 65536 --max-num-seqs 2 --max-num-batched-tokens 4096 \
+  --gpu-memory-utilization 0.80 --no-enable-flashinfer-autotune \
+  --enforce-eager \
+  --reasoning-parser deepseek_v4 --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
+  --load-format safetensors --host 0.0.0.0 --port 8000
+```
+
+Notes:
+- **First cold start JIT-compiles flashinfer 0.6.14 kernels (~20 min).** Launch both ranks
+  together only after the cache is warm, or rank 1's Gloo barrier can time out
+  (`Application timeout caused pair closure`). Persist `/root/.cache/flashinfer`.
+- `--moe-backend marlin` covers the MXFP4/fp8 expert checkpoints; `--linear-backend triton`
+  covers the E8M0 fp8 linears (with the overlay upcast).
+- `NCCL 2.28.9` in the base works cross-node over RoCE as-is (no LD_PRELOAD needed).
+- **Known issue — batched long-context decode wedges the engine; run `--enforce-eager`
+  and `--max-num-seqs 2`.** With any cudagraph mode (FULL, PIECEWISE, or the base's
+  auto-enabled breakable-cudagraph) the workers go silent during batched decode once
+  accumulated contexts grow past a few thousand tokens; `sample_tokens` RPC times out and
+  the engine dies. `VLLM_USE_BREAKABLE_CUDAGRAPH=0` extends survival ~6× and eager mode +
+  `max_num_seqs 2` is fully stable (complete 12-category multi-turn benchmark, 48/48 turns,
+  zero engine errors). Suspect: sparse-MLA decode path (nv_dev paged-MQA / persistent_topk /
+  flashinfer trtllm sparse) at batch>2 with long contexts — needs kernel-level investigation.
+  `VLLM_RPC_TIMEOUT=3600000` + `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3600` are belt-and-braces
+  for first-contact Triton JIT spikes; persist `/root/.triton` so those compile only once.
+
+## Validation (2× DGX Spark GB10, DeepSeek-V4-Flash-DSpark fp8)
+
+- Engine init 58 s (warm cache); GPU KV cache **782,838 tokens** (gpu_mem_util 0.80).
+- Numerically sane at temp 0 (exact-arithmetic + factual probes match a known-good
+  independent GB10 build within phrasing variance); coherent long-form generation; a full
+  12-category multi-turn benchmark graded at quality parity with that independent build.
+- Final config (eager, max_num_seqs 2): **complete benchmark run with zero engine errors —
+  48/48 turns**, single-stream decode **17.8 tok/s** (TTFT ~2.8 s), **28.6 tok/s aggregate**
+  across 10 concurrent multi-turn categories.
+- 2×10 concurrent 1500-token generations: 20/20 HTTP 200, engine alive.

--- a/overlay-deepseek-v4-gb10/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/overlay-deepseek-v4-gb10/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.compressed_tensors.triton_scaled_mm import (  # noqa: E501
+    triton_scaled_mm,
+)
+from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    convert_to_channelwise,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .BlockScaledMMLinearKernel import (
+    Fp8BlockScaledMMLinearKernel,
+)
+from .cutlass import CutlassInt8ScaledMMLinearKernel
+from .ScaledMMLinearKernel import (
+    Int8ScaledMMLinearLayerConfig,
+)
+
+
+class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if current_platform.is_cuda_alike():
+            return True, None
+        return False, "requires ROCm or CUDA."
+
+    @classmethod
+    def can_implement(cls, c: Int8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        w_q, _, i_s, _, _ = self._get_layer_params(layer)
+        w_q_name, w_s_name, i_s_name, i_zp_name, azp_adj_name = self.layer_param_names
+
+        replace_parameter(
+            layer,
+            w_q_name,
+            torch.nn.Parameter(w_q.t().data, requires_grad=False),
+        )
+
+        # WEIGHT SCALE
+        # Triton kernel supports only per-tensor and per-channel.
+        # If we have a fused module (QKV, MLP) with per tensor scales (thus N
+        # scales being passed to the kernel), convert to the per-channel case.
+        is_fused_module = len(layer.logical_widths) > 1
+        weight_scale = getattr(layer, w_s_name)
+        if is_fused_module and not self.config.is_channelwise:
+            weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
+        replace_parameter(
+            layer,
+            w_s_name,
+            torch.nn.Parameter(weight_scale.data, requires_grad=False),
+        )
+
+        # INPUT SCALE
+        if self.config.is_static_input_scheme:
+            assert i_s is not None
+
+            if self.config.input_symmetric:
+                replace_parameter(
+                    layer,
+                    i_s_name,
+                    torch.nn.Parameter(i_s.max(), requires_grad=False),
+                )
+                setattr(layer, i_zp_name, None)
+            else:
+                input_zero_point = getattr(layer, i_zp_name)
+
+                # Reconstruct the ranges to find a single scale and azp
+                int8_traits = torch.iinfo(torch.int8)
+                azps = input_zero_point.to(dtype=torch.int32)
+                range_max = (i_s * (int8_traits.max - azps)).max()
+                range_min = (i_s * (int8_traits.min - azps)).min()
+
+                scale = (range_max - range_min) / (int8_traits.max - int8_traits.min)
+                replace_parameter(
+                    layer,
+                    i_s_name,
+                    torch.nn.Parameter(scale, requires_grad=False),
+                )
+
+                # AZP loaded as int8 but used as int32
+                azp = (int8_traits.min - range_min / scale).to(dtype=torch.int32)
+                replace_parameter(
+                    layer,
+                    i_zp_name,
+                    torch.nn.Parameter(azp, requires_grad=False),
+                )
+        else:
+            setattr(layer, i_s_name, None)
+            setattr(layer, i_zp_name, None)
+
+        # azp_adj is the AZP adjustment term, used to account for weights.
+        # It does not depend on scales or azp, so it is the same for
+        # static and dynamic quantization.
+        # See csrc/quantization/w8a8/cutlass/Epilogues.md for the math.
+        if not self.config.input_symmetric:
+            weight = getattr(layer, w_q_name)
+            # weight is already transposed to [K, N], sum over K (dim=0)
+            azp_adj = weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+            if self.config.is_static_input_scheme:
+                # Fold azp into azp_adj for the per-tensor case
+                azp_adj = getattr(layer, i_zp_name) * azp_adj
+            setattr(
+                layer,
+                azp_adj_name,
+                torch.nn.Parameter(azp_adj, requires_grad=False),
+            )
+        else:
+            setattr(layer, azp_adj_name, None)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        w_q, w_s, i_s, i_zp, azp_adj = self._get_layer_params(layer)
+
+        symmetric = azp_adj is None
+        x_q, x_s, x_zp = ops.scaled_int8_quant(
+            x.contiguous(), i_s, i_zp, symmetric=symmetric
+        )
+
+        out = triton_scaled_mm(
+            x_q, w_q, scale_a=x_s, scale_b=w_s, out_dtype=x.dtype, bias=bias
+        )
+
+        if azp_adj is not None:
+            # Asymmetric quantization: subtract the zero-point correction.
+            # D = scale_a * scale_b * (A_q @ B_q - azp * azp_adj) + bias
+            # triton_scaled_mm already computed scale_a * scale_b * (A_q @ B_q) + bias
+            # so we subtract scale_a * scale_b * azp * azp_adj
+            #
+            # x_s: [M, 1] or scalar, w_s: [N, 1] or scalar, azp_adj: [1, N]
+            # Reshape w_s from [N, 1] to [1, N] for proper broadcasting.
+            w_s_row = w_s.view(1, -1) if w_s.dim() > 0 else w_s
+            static = i_zp is not None
+            if not static and x_zp is not None:
+                # Dynamic per-token: azp is per-token, azp_adj is per-channel
+                # x_zp: [M, 1], azp_adj: [1, N]
+                out -= x_s * w_s_row * (x_zp * azp_adj).to(x.dtype)
+            else:
+                # Static per-tensor: azp already folded into azp_adj
+                out -= (x_s * w_s_row * azp_adj).to(x.dtype)
+
+        return out
+
+
+class TritonFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
+    @classmethod
+    def is_supported(cls, compute_capability=None):
+        if not (current_platform.is_cuda_alike() or current_platform.is_xpu()):
+            return False, "only CUDA-alike and XPU devices are supported."
+        return True, None
+
+    def apply_block_scaled_mm(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.vllm.w8a8_triton_block_scaled_mm_func(
+            A,
+            B,
+            As,
+            Bs,
+            list(self.weight_group_shape),
+            self.config.out_dtype,
+        )
+
+
+# TODO we should be able to change the type of block_size to GroupShape
+# after we resolve GroupShape compilation issue
+# https://github.com/vllm-project/vllm/issues/25270
+def _w8a8_triton_block_scaled_mm_func(
+    qx: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    block_size: list[int],
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        w8a8_triton_block_scaled_mm,
+    )
+
+    # PATCH sm12x: triton JIT has no float8_e8m0fnu mapping; E8M0 is a pure power-of-2
+    # exponent so casting to f32 is exact and preserves the scale values.
+    if x_scale.dtype == torch.float8_e8m0fnu:
+        x_scale = x_scale.to(torch.float32)
+    if weight_scale.dtype == torch.float8_e8m0fnu:
+        weight_scale = weight_scale.to(torch.float32)
+    return w8a8_triton_block_scaled_mm(
+        qx, weight, x_scale, weight_scale, block_size, output_dtype
+    )
+
+
+def _w8a8_triton_block_scaled_mm_fake(
+    qx: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    block_size: list[int],
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    return torch.empty(
+        (qx.size(0), weight.size(0)), dtype=output_dtype, device=qx.device
+    )
+
+
+direct_register_custom_op(
+    "w8a8_triton_block_scaled_mm_func",
+    _w8a8_triton_block_scaled_mm_func,
+    fake_impl=_w8a8_triton_block_scaled_mm_fake,
+)

--- a/overlay-deepseek-v4-gb10/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/overlay-deepseek-v4-gb10/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1,0 +1,566 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Custom Sparse Attention Indexer layers."""
+
+import torch
+
+import vllm.envs as envs
+from vllm import _custom_ops as ops
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import (
+    fp8_fp4_mqa_logits,
+    fp8_fp4_paged_mqa_logits,
+    has_deep_gemm,
+)
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadata,
+)
+from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.worker.workspace import current_workspace_manager
+
+logger = init_logger(__name__)
+
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+# MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
+MXFP4_BLOCK_SIZE = 32
+
+
+def _gather_workspace_shapes(
+    total_seq_lens: int,
+    head_dim: int,
+    fp8_dtype: torch.dtype,
+    use_fp4_cache: bool,
+) -> tuple[tuple[tuple[int, int], torch.dtype], tuple[tuple[int, int], torch.dtype]]:
+    """Return ((values_shape, values_dtype), (scales_shape, scales_dtype)) for
+    the K-gather workspace. FP8 path: (T, head_dim) fp8 + (T, 4) uint8 fp32
+    scales. MXFP4 path: (T, head_dim // 2) uint8 packed mxfp4 +
+    (T, head_dim // MXFP4_BLOCK_SIZE) uint8 ue8m0 scales."""
+    if use_fp4_cache:
+        return (
+            ((total_seq_lens, head_dim // 2), torch.uint8),
+            ((total_seq_lens, head_dim // MXFP4_BLOCK_SIZE), torch.uint8),
+        )
+    return (
+        ((total_seq_lens, head_dim), fp8_dtype),
+        ((total_seq_lens, 4), torch.uint8),
+    )
+
+
+def kv_cache_as_quant_view(
+    kv_cache: torch.Tensor,
+    head_dim: int,
+    use_fp4_cache: bool,
+) -> torch.Tensor:
+    """4D ``[num_blocks, block_size, 1, head_width]`` view expected by
+    DeepGEMM, from the 3D indexer kv-cache allocation."""
+    if use_fp4_cache:
+        assert kv_cache.ndim == 3 and kv_cache.dtype == torch.uint8
+        num_blocks, block_size, _ = kv_cache.shape
+        page_bytes = int(kv_cache.stride(0))
+        fp4_bytes = head_dim // 2 + head_dim // MXFP4_BLOCK_SIZE
+        return torch.as_strided(
+            kv_cache,
+            size=(num_blocks, block_size, 1, fp4_bytes),
+            stride=(page_bytes, fp4_bytes, fp4_bytes, 1),
+        )
+    return kv_cache.unsqueeze(-2)
+
+
+@eager_break_during_capture
+def sparse_attn_indexer(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    q_scale: torch.Tensor | None,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor,
+    skip_k_cache_insert: bool,
+    use_fp4_cache: bool = False,
+) -> torch.Tensor:
+    # careful! this will be None in dummy run
+    attn_metadata = get_forward_context().attn_metadata
+    fp8_dtype = current_platform.fp8_dtype()
+    k_cache_prefix = _resolve_layer_name(k_cache_prefix)
+
+    # assert isinstance(attn_metadata, dict)
+    if not isinstance(attn_metadata, dict):
+        # Reserve workspace for indexer during profiling run
+        values_spec, scales_spec = _gather_workspace_shapes(
+            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+        )
+        current_workspace_manager().get_simultaneous(
+            values_spec,
+            scales_spec,
+            ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+        )
+
+        # Dummy allocation to simulate for peak logits tensor memory during inference.
+        # FP8 elements so elements == bytes
+        max_logits_elems = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+        _ = torch.empty(
+            max_logits_elems, dtype=torch.uint8, device=hidden_states.device
+        )
+
+        return sparse_attn_indexer_fake(
+            hidden_states,
+            k_cache_prefix,
+            kv_cache,
+            q_quant,
+            q_scale,
+            k,
+            weights,
+            quant_block_size,
+            scale_fmt,
+            topk_tokens,
+            head_dim,
+            max_model_len,
+            total_seq_lens,
+            topk_indices_buffer,
+            skip_k_cache_insert,
+            use_fp4_cache,
+        )
+    attn_metadata_narrowed = attn_metadata[k_cache_prefix]
+    assert isinstance(attn_metadata_narrowed, DeepseekV32IndexerMetadata)
+    slot_mapping = attn_metadata_narrowed.slot_mapping
+    has_decode = attn_metadata_narrowed.num_decodes > 0
+    has_prefill = attn_metadata_narrowed.num_prefills > 0
+    num_decode_tokens = attn_metadata_narrowed.num_decode_tokens
+
+    # q_scale is required iff the FP4 cache path is enabled; the FP8 path
+    # folds the Q scale into `weights` inside fused_indexer_q_rope_quant.
+    if use_fp4_cache:
+        assert q_scale is not None, "use_fp4_cache=True requires q_scale"
+    else:
+        assert q_scale is None, "q_scale must be None when use_fp4_cache=False"
+
+    # During speculative decoding, k may be padded to the CUDA graph batch
+    # size while slot_mapping only covers actual tokens. Truncate k to avoid
+    # out-of-bounds reads in the kernel.
+    num_tokens = slot_mapping.shape[0]
+    if k is not None:
+        k = k[:num_tokens]
+
+    if not skip_k_cache_insert:
+        # scale_fmt can be None, but the function expects str
+        assert scale_fmt is not None
+        assert not use_fp4_cache, "Unfused FP4 Insert is not supported yet"
+        ops.indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+        )
+
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
+    if has_prefill:
+        prefill_metadata = attn_metadata_narrowed.prefill
+        assert prefill_metadata is not None
+
+        # Get the full shared workspace buffers once (will allocate on first use).
+        # Layout switches between FP8 (head_dim bytes + 4-byte fp32 scale) and
+        # MXFP4 (head_dim/2 bytes packed + head_dim/MXFP4_BLOCK_SIZE ue8m0
+        # scales) based on use_fp4_cache.
+        workspace_manager = current_workspace_manager()
+        values_spec, scales_spec = _gather_workspace_shapes(
+            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+        )
+        k_quant_full, k_scale_full = workspace_manager.get_simultaneous(
+            values_spec,
+            scales_spec,
+        )
+        for chunk in prefill_metadata.chunks:
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+
+            if not chunk.skip_kv_gather:
+                ops.cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_quant,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
+
+            q_slice = q_quant[chunk.token_start : chunk.token_end]
+            q_scale_slice = (
+                q_scale[chunk.token_start : chunk.token_end]
+                if q_scale is not None
+                else None
+            )
+            # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
+            # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
+            if use_fp4_cache:
+                q_slice_cast = q_slice.view(torch.int8)
+                k_quant_cast = k_quant.view(torch.int8)
+                k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
+            else:
+                q_slice_cast = q_slice
+                k_quant_cast = k_quant
+                k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
+            if current_platform.is_xpu():
+                if q_scale_slice is not None:
+                    raise RuntimeError("XPU fp8_mqa_logits does not support FP4 Q")
+                logits = torch.ops.vllm.xpu_fp8_mqa_logits(
+                    q_slice_cast,
+                    k_quant_cast,
+                    k_scale_cast,
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                )
+            else:
+                logits = fp8_fp4_mqa_logits(
+                    (q_slice_cast, q_scale_slice),
+                    (k_quant_cast, k_scale_cast),
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    clean_logits=False,
+                )
+            num_rows = logits.shape[0]
+
+            topk_indices = topk_indices_buffer[
+                chunk.token_start : chunk.token_end, :topk_tokens
+            ]
+
+            ops.top_k_per_row_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
+
+    if has_decode:
+        decode_metadata = attn_metadata_narrowed.decode
+        assert decode_metadata is not None
+        kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
+        decode_lens = decode_metadata.decode_lens
+        if decode_metadata.requires_padding:
+            # pad in edge case where we have short chunked prefill length <
+            # decode_threshold since we unstrictly split
+            # prefill and decode by decode_threshold
+            # (currently set to 1 + speculative tokens).
+            # FP8 Q is float8_e4m3fn (pack_seq_triton's fp32 pad path is OK —
+            # downstream context_lens masks stale slots). MXFP4 Q is two
+            # uint8 tensors (values + ue8m0 scales) — use the dedicated uint8
+            # packer with pad_byte=0 so padded slots dequantize to 0 and
+            # can't produce NaN/Inf in the logits kernel.
+            if q_scale is not None:
+                padded_q_quant_decode_tokens = pack_seq_triton(
+                    q_quant[:num_decode_tokens], decode_lens, pad_value=0
+                )
+                padded_q_scale = pack_seq_triton(
+                    q_scale[:num_decode_tokens], decode_lens, pad_value=0
+                )
+            else:
+                padded_q_quant_decode_tokens = pack_seq_triton(
+                    q_quant[:num_decode_tokens], decode_lens
+                )
+                padded_q_scale = None
+        else:
+            padded_q_quant_decode_tokens = q_quant[:num_decode_tokens].reshape(
+                decode_lens.shape[0], -1, *q_quant.shape[1:]
+            )
+            if q_scale is not None:
+                padded_q_scale = q_scale[:num_decode_tokens].reshape(
+                    decode_lens.shape[0], -1, *q_scale.shape[1:]
+                )
+            else:
+                padded_q_scale = None
+        # TODO: move and optimize below logic with triton kernels
+        batch_size = padded_q_quant_decode_tokens.shape[0]
+        next_n = padded_q_quant_decode_tokens.shape[1]
+        num_padded_tokens = batch_size * next_n
+        seq_lens = decode_metadata.seq_lens[:batch_size]
+        # seq_lens is always 2D: (B, next_n) for native spec decode, (B, 1)
+        # otherwise. deep_gemm fp8_fp4_paged_mqa_logits requires 2D context_lens;
+        # the downstream topk kernels accept both 1D and 2D.
+        padded_q_quant_cast = (
+            padded_q_quant_decode_tokens.view(torch.int8)
+            if use_fp4_cache
+            else padded_q_quant_decode_tokens
+        )
+        if current_platform.is_xpu():
+            if padded_q_scale is not None:
+                raise RuntimeError("XPU fp8_paged_mqa_logits does not support FP4 Q")
+            seq_lens_xpu = (
+                seq_lens[:, -1].contiguous() if seq_lens.ndim == 2 else seq_lens
+            )
+            logits = torch.ops.vllm.xpu_fp8_paged_mqa_logits(
+                padded_q_quant_cast,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens_xpu,
+                decode_metadata.block_table,
+                decode_metadata.schedule_metadata,
+                max_model_len,
+            )
+        else:
+            logits = fp8_fp4_paged_mqa_logits(
+                (padded_q_quant_cast, padded_q_scale),
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                decode_metadata.schedule_metadata,
+                max_model_len=max_model_len,
+                clean_logits=False,
+            )
+        num_rows = logits.shape[0]
+        topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+
+        use_cooperative_topk = (
+            current_platform.is_cuda()
+            and topk_tokens in (512, 1024, 2048)
+            and num_rows <= 32
+            and logits.stride(0) % 4 == 0  # TMA 16-byte alignment
+            and current_platform.has_device_capability(90)
+            # sm12x (GB10): cooperative cluster launch fails ("invalid argument");
+            # fall through to persistent_topk which is exact and sm12x-safe.
+            and not current_platform.has_device_capability(120)
+        )
+        use_persistent_topk = current_platform.is_cuda() and topk_tokens in (
+            512,
+            1024,
+            2048,
+        )
+        if use_cooperative_topk:
+            workspace_manager = current_workspace_manager()
+            (topk_workspace,) = workspace_manager.get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+            torch.ops._C.cooperative_topk(
+                logits,
+                seq_lens,
+                topk_indices,
+                topk_workspace,
+                topk_tokens,
+                attn_metadata_narrowed.max_seq_len,
+            )
+        elif use_persistent_topk:
+            workspace_manager = current_workspace_manager()
+            (topk_workspace,) = workspace_manager.get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+            torch.ops._C.persistent_topk(
+                logits,
+                seq_lens,
+                topk_indices,
+                topk_workspace,
+                topk_tokens,
+                attn_metadata_narrowed.max_seq_len,
+            )
+        else:
+            ops.top_k_per_row_decode(
+                logits,
+                next_n,
+                seq_lens,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
+
+        if decode_metadata.requires_padding:
+            # if padded, we need to unpack
+            # the topk indices removing padded tokens
+            topk_indices = unpack_seq_triton(
+                topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
+                decode_lens,
+            )
+            topk_indices_buffer[: topk_indices.shape[0], : topk_indices.shape[-1]] = (
+                topk_indices
+            )
+
+    return topk_indices_buffer
+
+
+def sparse_attn_indexer_fake(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    q_scale: torch.Tensor | None,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor | None,
+    skip_k_cache_insert: bool,
+    use_fp4_cache: bool = False,
+) -> torch.Tensor:
+    return topk_indices_buffer
+
+
+direct_register_custom_op(
+    op_name="sparse_attn_indexer",
+    op_func=sparse_attn_indexer,
+    mutates_args=["topk_indices_buffer"],
+    fake_impl=sparse_attn_indexer_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+@CustomOp.register("sparse_attn_indexer")
+class SparseAttnIndexer(CustomOp):
+    """Sparse Attention Indexer Custom Op Layer. This layer is extracted as a
+    separate custom op since it involves heavy custom kernels like `mqa_logits`,
+    `paged_mqa_logits` and `top_k_per_row`, etc. Those kernels maybe requires
+    specific memory layout or implementation for different hardware backends to
+    achieve optimal performance.
+
+    For now, the default native path will use CUDA backend path. Other platform
+    may requires add the corresponding Custom Op name `sparse_attn_indexer` to
+    `custom_ops` in `CompilationConfig` to enable the platform specific path.
+    """
+
+    def __init__(
+        self,
+        k_cache,
+        quant_block_size: int,
+        scale_fmt: str,
+        topk_tokens: int,
+        head_dim: int,
+        max_model_len: int,
+        max_total_seq_len: int,
+        topk_indices_buffer: torch.Tensor,
+        skip_k_cache_insert: bool = False,
+        use_fp4_cache: bool = False,
+    ):
+        super().__init__()
+        self.k_cache = k_cache
+        self.quant_block_size = quant_block_size
+        self.scale_fmt = scale_fmt
+        self.topk_tokens = topk_tokens
+        self.head_dim = head_dim
+        self.max_model_len = max_model_len
+        self.max_total_seq_len = max_total_seq_len
+        self.topk_indices_buffer = topk_indices_buffer
+        self.skip_k_cache_insert = skip_k_cache_insert
+        self.use_fp4_cache = use_fp4_cache
+        if current_platform.is_cuda() and not has_deep_gemm():
+            raise RuntimeError(
+                "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
+                "the current vLLM environment."
+            )
+
+    def forward_native(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        if current_platform.is_cuda() or current_platform.is_xpu():
+            return self.forward_cuda(hidden_states, q_quant, k, weights)
+        elif current_platform.is_rocm():
+            return self.forward_hip(hidden_states, q_quant, k, weights)
+        else:
+            raise NotImplementedError(
+                "SparseAttnIndexer native forward is only implemented for "
+                "CUDA, ROCm and XPU platforms."
+            )
+
+    def forward_cuda(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        # FP8 path: single tensor (per-token scale is folded into `weights`).
+        # FP4 path: (values, scales) tuple with scales required by the kernel.
+        if isinstance(q_quant, tuple):
+            q_values, q_scale = q_quant
+        else:
+            q_values, q_scale = q_quant, None
+        return torch.ops.vllm.sparse_attn_indexer(
+            hidden_states,
+            _encode_layer_name(self.k_cache.prefix),
+            self.k_cache.kv_cache,
+            q_values,
+            q_scale,
+            k,
+            weights,
+            self.quant_block_size,
+            self.scale_fmt,
+            self.topk_tokens,
+            self.head_dim,
+            self.max_model_len,
+            self.max_total_seq_len,
+            self.topk_indices_buffer,
+            self.skip_k_cache_insert,
+            self.use_fp4_cache,
+        )
+
+    def forward_xpu(
+        self,
+        hidden_states: torch.Tensor,
+        q_fp8: torch.Tensor,
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        return self.forward_cuda(hidden_states, q_fp8, k, weights)
+
+    def forward_hip(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        assert not self.use_fp4_cache, "AMD platform doesn't support fp4 cache yet"
+        assert isinstance(q_quant, torch.Tensor), (
+            "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
+        )
+        if rocm_aiter_ops.is_enabled():
+            return torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
+                hidden_states,
+                _encode_layer_name(self.k_cache.prefix),
+                self.k_cache.kv_cache,
+                q_quant,
+                k,
+                weights,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                skip_k_cache_insert=self.skip_k_cache_insert,
+            )
+        raise RuntimeError(
+            "Sparse attention indexer ROCm path is only supported on AITER. "
+            "Please enable aiter with VLLM_ROCM_USE_AITER=1"
+        )

--- a/overlay-deepseek-v4-gb10/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/overlay-deepseek-v4-gb10/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# PATCHED (sm12x / GB10): adapt the o_proj fp8_einsum call to DeepGEMM nv_dev (PR #324 sm120 kernels).
+# AEON's SM100 path passes int32-packed UE8M0 activation scales, a 2D (h*d, r) weight, and a 2D e8m0
+# weight scale. nv_dev's fp8_einsum('bhr,hdr->bhd') expects unpacked fp32 scales and a 3D (h,d,r)
+# weight (see DeepGEMM tests/test_einsum.py::test_fp8_bhr_hdr_bhd). This shim converts on sm12x only.
+import torch
+import torch.nn as nn
+
+from vllm.models.deepseek_v4.common.ops.fused_inv_rope_fp8_quant import (
+    fused_inv_rope_fp8_quant,
+)
+from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import fp8_einsum
+
+_USE_SM12X = None
+
+
+def _sm12x() -> bool:
+    global _USE_SM12X
+    if _USE_SM12X is None:
+        cap = current_platform.get_device_capability()
+        _USE_SM12X = cap is not None and cap.major >= 12
+    return _USE_SM12X
+
+
+def _ue8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    """UE8M0 -> fp32 (exact): place the 8-bit exponent into the fp32 exponent field.
+    Handles int32-packed (4 UE8M0 bytes per int32, little-endian) and raw float8_e8m0fnu."""
+    e8 = getattr(torch, "float8_e8m0fnu", None)
+    if scale.dtype == torch.int32:
+        u8 = scale.contiguous().view(torch.uint8)      # [..., k*4] bytes in logical order
+    elif e8 is not None and scale.dtype == e8:
+        u8 = scale.contiguous().view(torch.uint8)
+    else:
+        return scale.to(torch.float32)
+    return (u8.to(torch.int32) << 23).view(torch.float32)
+
+
+def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
+    """fp8_einsum recipe + scale layout for the current GPU arch.
+
+    SM90: FP32 block scales stay [g, r/128, d/128] -> sfb_gran_mn=128.
+    SM100: INT32 packed scales become [g, r, ...] -> sfb_gran_mn=1.
+
+    Returns ``(einsum_recipe, tma_aligned_scales)`` for ``deep_gemm_fp8_o_proj``.
+    """
+    cap = current_platform.get_device_capability()
+    assert cap is not None, "DeepseekV4 attention requires a CUDA device"
+    einsum_recipe = (1, 128, 128) if cap.major <= 9 else (1, 1, 128)
+    tma_aligned_scales = cap.major >= 10
+    return einsum_recipe, tma_aligned_scales
+
+
+def deep_gemm_fp8_o_proj(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    wo_a: nn.Module,
+    wo_b: nn.Module,
+    *,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    o_lora_rank: int,
+    einsum_recipe: tuple[int, int, int],
+    tma_aligned_scales: bool,
+) -> torch.Tensor:
+    """O projection: inverse RoPE + FP8 quant + einsum + wo_b."""
+    o_fp8, o_scale = fused_inv_rope_fp8_quant(
+        o,
+        positions,
+        cos_sin_cache,
+        n_groups=n_groups,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        tma_aligned_scales=tma_aligned_scales,
+    )
+    z = torch.empty(
+        (o.shape[0], n_groups, o_lora_rank),
+        device=o.device,
+        dtype=torch.bfloat16,
+    )
+    if _sm12x():
+        # nv_dev sm120 einsum: unpacked fp32 scales + 3D weight.
+        b, h, r = o_fp8.shape
+        d = o_lora_rank
+        o_s = _ue8m0_to_fp32(o_scale).reshape(b, h, -1)[:, :, : (r + 127) // 128]
+        w3 = getattr(wo_a, "_sm12x_w3", None)
+        if w3 is None:
+            w3 = wo_a.weight.reshape(h, d, r)
+            ws = (
+                _ue8m0_to_fp32(wo_a.weight_scale_inv)
+                .reshape(h, (d + 127) // 128, (r + 127) // 128)
+                .contiguous()
+            )
+            wo_a._sm12x_w3, wo_a._sm12x_ws = w3, ws
+        fp8_einsum("bhr,hdr->bhd", (o_fp8, o_s.contiguous()), (w3, wo_a._sm12x_ws), z)
+    else:
+        fp8_einsum(
+            "bhr,hdr->bhd",
+            (o_fp8, o_scale),
+            (wo_a.weight, wo_a.weight_scale_inv),
+            z,
+            recipe=einsum_recipe,
+        )
+    return wo_b(z.flatten(1))

--- a/overlay-deepseek-v4-gb10/vllm/vllm_flash_attn/cute/utils.py
+++ b/overlay-deepseek-v4-gb10/vllm/vllm_flash_attn/cute/utils.py
@@ -1,0 +1,973 @@
+# Copyright (c) 2025, Tri Dao.
+
+import math
+import hashlib
+import inspect
+import os
+from functools import partial
+from typing import Type, Callable, Optional, Tuple, overload
+
+import cutlass
+import cutlass.cute as cute
+
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute import FastDivmodDivisor
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import nvvm, llvm
+from cutlass.cute.runtime import from_dlpack
+
+
+import quack.activation
+
+_MIXER_ATTRS = ("__vec_size__",)
+
+# Obtained from sollya:
+# fpminimax(exp(x * log(2.0)), 1, [|1,24...|],[0;1],relative);
+POLY_EX2 = {
+    0: (1.0),
+    1: (
+        1.0,
+        0.922497093677520751953125,
+    ),
+    2: (
+        1.0,
+        0.6657850742340087890625,
+        0.330107033252716064453125,
+    ),
+    3: (
+        1.0,
+        0.695146143436431884765625,
+        0.227564394474029541015625,
+        0.077119089663028717041015625,
+    ),
+    4: (
+        1.0,
+        0.693042695522308349609375,
+        0.2412912547588348388671875,
+        5.2225358784198760986328125e-2,
+        1.3434938155114650726318359375e-2,
+    ),
+    5: (
+        1.0,
+        0.693151414394378662109375,
+        0.24016360938549041748046875,
+        5.5802188813686370849609375e-2,
+        9.01452265679836273193359375e-3,
+        1.86810153536498546600341796875e-3,
+    ),
+}
+
+_fa_clc_enabled: bool = os.environ.get("FA_CLC", "0") == "1"
+_fa_disable_2cta_enabled: bool = os.environ.get("FA_DISABLE_2CTA", "0") == "1"
+
+
+def _is_cuda_12() -> bool:
+    """Check if the CUDA toolkit version is 12.x.
+
+    2CTA forward non-causal has a codegen regression on CUDA 12 that causes
+    ~18% slowdown compared to 1CTA. This is fixed in CUDA 13.x.
+    """
+    try:
+        import torch
+
+        cuda_version = torch.version.cuda
+        if cuda_version is not None:
+            major = cuda_version.split(".")[0]
+            return int(major) == 12
+    except Exception:
+        pass
+    return False
+
+
+_fa_disable_2cta_cuda12: bool = _is_cuda_12()
+
+
+def _get_use_clc_scheduler_default() -> bool:
+    return _fa_clc_enabled
+
+
+def _get_disable_2cta_default(is_fwd: bool = False) -> bool:
+    if is_fwd:
+        return _fa_disable_2cta_enabled or _fa_disable_2cta_cuda12
+    else:
+        return _fa_disable_2cta_enabled
+
+
+def _compute_base_hash(func: Callable) -> str:
+    """Compute hash from source code or bytecode and closure values."""
+    try:
+        data = inspect.getsource(func).encode()
+    except (OSError, TypeError):
+        if hasattr(func, "__code__") and func.__code__ is not None:
+            data = func.__code__.co_code
+        else:
+            data = repr(func).encode()
+
+    hasher = hashlib.sha256(data)
+
+    if hasattr(func, "__closure__") and func.__closure__ is not None:
+        for cell in func.__closure__:
+            hasher.update(repr(cell.cell_contents).encode())
+
+    return hasher.hexdigest()
+
+
+def hash_callable(
+    func: Callable, mixer_attrs: Tuple[str] = _MIXER_ATTRS, set_cute_hash: bool = True
+) -> str:
+    """Hash a callable based on the source code or bytecode and closure values.
+    Fast-path: if the callable (or its __wrapped__ base) has a ``__cute_hash__``
+    attribute, that value is returned immediately as the base hash, then
+    metadata dunders are mixed in to produce the final dict-key hash.
+    set_cute_hash: whether or not to set func.__cute_hash__
+    """
+    # Resolve base hash
+    if hasattr(func, "__cute_hash__"):
+        base_hash = func.__cute_hash__
+    else:
+        # Unwrap decorated functions (e.g., cute.jit wrappers).
+        base_func = getattr(func, "__wrapped__", func)
+
+        if hasattr(base_func, "__cute_hash__"):
+            base_hash = base_func.__cute_hash__
+        else:
+            base_hash = _compute_base_hash(base_func)
+
+            if set_cute_hash:
+                base_func.__cute_hash__ = base_hash
+
+    # Mix in mutable metadata dunders
+    mixer_values = tuple(getattr(func, attr, None) for attr in mixer_attrs)
+
+    if all(v is None for v in mixer_values):
+        return base_hash
+
+    hasher = hashlib.sha256(base_hash.encode())
+
+    for attr, val in zip(mixer_attrs, mixer_values):
+        hasher.update(f"{attr}={val!r}".encode())
+
+    return hasher.hexdigest()
+
+
+def create_softcap_scoremod(softcap_val):
+    @cute.jit
+    def scoremod_premask_fn(
+        acc_S_SSA, batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        scores = acc_S_SSA / softcap_val
+        return softcap_val * cute.math.tanh(scores, fastmath=True)
+
+    return scoremod_premask_fn
+
+
+def create_softcap_scoremod_bwd(softcap_val):
+    @cute.jit
+    def scoremod_bwd_fn(
+        grad_out_SSA, score_SSA, batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        scores = score_SSA / softcap_val
+        tanh_scores = cute.math.tanh(scores, fastmath=True)
+        return grad_out_SSA * (1.0 - tanh_scores * tanh_scores)
+
+    return scoremod_bwd_fn
+
+
+LOG2_E = math.log2(math.e)
+
+
+def compute_softmax_scale_log2(softmax_scale, score_mod):
+    """Compute softmax_scale_log2 and adjusted softmax_scale based on whether score_mod is used.
+
+    When score_mod is None, fold the log2(e) factor into softmax_scale_log2 and set softmax_scale
+    to None. When score_mod is present, keep softmax_scale separate so it can be applied before
+    the score_mod, and set softmax_scale_log2 to just the change-of-base constant.
+
+    Returns (softmax_scale_log2, softmax_scale).
+    """
+    if const_expr(score_mod is None):
+        return softmax_scale * LOG2_E, None
+    else:
+        return LOG2_E, softmax_scale
+
+
+def compute_fastdiv_mods(mQ, mK, qhead_per_kvhead, pack_gqa, aux_tensors, mPageTable=None):
+    """Compute FastDivmodDivisor pairs for aux_tensors index computation.
+
+    Returns a (seqlen_q_divmod, seqlen_k_divmod) tuple, or None if aux_tensors is None.
+    """
+    if const_expr(aux_tensors is None):
+        return None
+    seqlen_q = cute.size(mQ.shape[0]) // (qhead_per_kvhead if const_expr(pack_gqa) else 1)
+    seqlen_k = (
+        cute.size(mK.shape[0])
+        if const_expr(mPageTable is None)
+        else mK.shape[0] * mPageTable.shape[1]
+    )
+    return (FastDivmodDivisor(seqlen_q), FastDivmodDivisor(seqlen_k))
+
+
+def convert_from_dlpack(x, leading_dim, alignment=16, divisibility=1) -> cute.Tensor:
+    return (
+        from_dlpack(x, assumed_align=alignment)
+        .mark_layout_dynamic(leading_dim=leading_dim)
+        .mark_compact_shape_dynamic(
+            mode=leading_dim, stride_order=x.dim_order(), divisibility=divisibility
+        )
+    )
+
+
+def convert_from_dlpack_compact_dynamic(
+    x,
+    *,
+    dynamic_modes: tuple[int, ...],
+    alignment: int = 16,
+    stride_order=None,
+    divisibility: int = 1,
+    enable_tvm_ffi: bool = False,
+) -> cute.Tensor:
+    """Convert via DLPack and mark selected compact dimensions as dynamic."""
+    if isinstance(dynamic_modes, int):
+        dynamic_modes = (dynamic_modes,)
+    if stride_order is None:
+        stride_order = x.dim_order()
+    t = (
+        from_dlpack(x, assumed_align=alignment, enable_tvm_ffi=True)
+        if enable_tvm_ffi
+        else from_dlpack(x, assumed_align=alignment)
+    )
+    for mode in dynamic_modes:
+        t = t.mark_compact_shape_dynamic(
+            mode=mode,
+            stride_order=stride_order,
+            divisibility=divisibility,
+        )
+    return t
+
+
+def convert_from_dlpack_leading_static(
+    x, leading_dim, alignment=16, static_modes=None, stride_order=None
+) -> cute.Tensor:
+    if stride_order is None:
+        stride_order = x.dim_order()
+    x_ = from_dlpack(x, assumed_align=alignment)
+    for i in range(x.ndim):
+        if i != leading_dim and (static_modes is None or i not in static_modes):
+            x_ = x_.mark_compact_shape_dynamic(mode=i, stride_order=stride_order)
+    return x_
+
+
+def make_tiled_copy_A(
+    copy_atom: cute.CopyAtom, tiled_mma: cute.TiledMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.TiledCopy:
+    if const_expr(swapAB):
+        return cute.make_tiled_copy_B(copy_atom, tiled_mma)
+    else:
+        return cute.make_tiled_copy_A(copy_atom, tiled_mma)
+
+
+def make_tiled_copy_B(
+    copy_atom: cute.CopyAtom, tiled_mma: cute.TiledMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.TiledCopy:
+    if const_expr(swapAB):
+        return cute.make_tiled_copy_A(copy_atom, tiled_mma)
+    else:
+        return cute.make_tiled_copy_B(copy_atom, tiled_mma)
+
+
+def mma_make_fragment_A(
+    smem: cute.Tensor, thr_mma: cute.core.ThrMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.Tensor:
+    if const_expr(swapAB):
+        return mma_make_fragment_B(smem, thr_mma)
+    else:
+        return thr_mma.make_fragment_A(thr_mma.partition_A(smem))
+
+
+def mma_make_fragment_B(
+    smem: cute.Tensor, thr_mma: cute.core.ThrMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.Tensor:
+    if const_expr(swapAB):
+        return mma_make_fragment_A(smem, thr_mma)
+    else:
+        return thr_mma.make_fragment_B(thr_mma.partition_B(smem))
+
+
+def get_smem_store_atom(
+    arch: cutlass.Constexpr[int], element_type: Type[cute.Numeric], transpose: bool = False
+) -> cute.CopyAtom:
+    if const_expr(arch < 90 or element_type.width != 16):
+        return cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            element_type,
+            num_bits_per_copy=2 * element_type.width,
+        )
+    else:
+        return cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(transpose=transpose, num_matrices=4),
+            element_type,
+        )
+
+
+@cute.jit
+def warp_reduce(
+    val: cute.TensorSSA | cute.Numeric,
+    op: Callable,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.TensorSSA | cute.Numeric:
+    if const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_fragment(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    else:
+        for i in cutlass.range_constexpr(int(math.log2(width))):
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1 << i))
+    return val
+
+
+@dsl_user_op
+def smid(*, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [],
+            "mov.u32 $0, %smid;",
+            "=r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmax(
+    a: float | Float32, b: float | Float32, c: float | Float32 | None = None, *, loc=None, ip=None
+) -> Float32:
+    from cutlass import CUDA_VERSION  # noqa: F401  (kept for reference)
+
+    # * NVVM call based on the actual binding signature, not the CUDA version:
+    # cutlass-dsl 4.6.0 still reports CUDA 12.9 in its toolchain metadata but ships the
+    # new nvvm bindings (result type inferred, params start at (a, b, ...)). Feature-
+    # detect the binding instead of trusting the version proxy.
+    import inspect as _inspect
+    _nvvm_params = list(_inspect.signature(nvvm.fmax).parameters)
+    if _nvvm_params[:2] != ["a", "b"]:
+        # Old API: requires explicit result type as first positional argument
+        return Float32(
+            nvvm.fmax(
+                T.f32(),
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+    else:
+        # New API: infers result type automatically
+        return Float32(
+            nvvm.fmax(
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+
+
+@cute.jit
+def fmax_reduce(
+    x: cute.TensorSSA, init_val: float | Float32 | None = None, arch: cutlass.Constexpr[int] = 80
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        # if const_expr(init_val is None):
+        #     init_val = -cutlass.Float32.if
+        # return x.reduce(cute.ReductionOp.MAX, init_val, 0)
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        # local_max = [res[0], res[1]]
+        # for i in cutlass.range_constexpr(2, cute.size(x.shape), 2):
+        #     local_max[0] = fmax(local_max[0], res[i + 0])
+        #     local_max[1] = fmax(local_max[1], res[i + 1])
+        # local_max[0] = fmax(local_max[0], local_max[1])
+        # return local_max[0] if const_expr(init_val is None) else fmax(local_max[0], init_val)
+        local_max = [res[0], res[1], res[2], res[3]]
+        for i in cutlass.range_constexpr(4, cute.size(x.shape), 4):
+            local_max[0] = fmax(local_max[0], res[i + 0])
+            local_max[1] = fmax(local_max[1], res[i + 1])
+            local_max[2] = fmax(local_max[2], res[i + 2])
+            local_max[3] = fmax(local_max[3], res[i + 3])
+        local_max[0] = fmax(local_max[0], local_max[1])
+        local_max[2] = fmax(local_max[2], local_max[3])
+        local_max[0] = fmax(local_max[0], local_max[2])
+        return local_max[0] if const_expr(init_val is None) else fmax(local_max[0], init_val)
+    else:
+        # [2025-06-15] x.reduce only seems to use 50% 3-input max and 50% 2-input max
+        # We instead force the 3-input max.
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        local_max_0 = (
+            fmax(init_val, res[0], res[1])
+            if const_expr(init_val is not None)
+            else fmax(res[0], res[1])
+        )
+        local_max = [
+            local_max_0,
+            fmax(res[2], res[3]),
+            fmax(res[4], res[5]),
+            fmax(res[6], res[7]),
+        ]
+        for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+            local_max[0] = fmax(local_max[0], res[i], res[i + 1])
+            local_max[1] = fmax(local_max[1], res[i + 2], res[i + 3])
+            local_max[2] = fmax(local_max[2], res[i + 4], res[i + 5])
+            local_max[3] = fmax(local_max[3], res[i + 6], res[i + 7])
+        local_max[0] = fmax(local_max[0], local_max[1])
+        return fmax(local_max[0], local_max[2], local_max[3])
+
+
+@cute.jit
+def fadd_reduce(
+    x: cute.TensorSSA, init_val: float | Float32 | None = None, arch: cutlass.Constexpr[int] = 80
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        if const_expr(init_val is None):
+            init_val = Float32.zero
+        return x.reduce(cute.ReductionOp.ADD, init_val, 0)
+        # res = cute.make_fragment(x.shape, Float32)
+        # res.store(x)
+        # local_sum = [res[0], res[1], res[2], res[3]]
+        # for i in cutlass.range_constexpr(4, cute.size(x.shape), 4):
+        #     local_sum[0] += res[i + 0]
+        #     local_sum[1] += res[i + 1]
+        #     local_sum[2] += res[i + 2]
+        #     local_sum[3] += res[i + 3]
+        # local_sum[0] += local_sum[1]
+        # local_sum[2] += local_sum[3]
+        # local_sum[0] += local_sum[2]
+        # return local_sum[0] if const_expr(init_val is None) else local_sum[0] + init_val
+    else:
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        local_sum_0 = (
+            cute.arch.add_packed_f32x2((init_val, 0.0), (res[0], res[1]))
+            # cute.arch.add_packed_f32x2((init_val / 2, init_val / 2), (res[0], res[1]))
+            if const_expr(init_val is not None)
+            else (res[0], res[1])
+        )
+        local_sum = [local_sum_0, (res[2], res[3]), (res[4], res[5]), (res[6], res[7])]
+        for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+            local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], (res[i + 0], res[i + 1]))
+            local_sum[1] = cute.arch.add_packed_f32x2(local_sum[1], (res[i + 2], res[i + 3]))
+            local_sum[2] = cute.arch.add_packed_f32x2(local_sum[2], (res[i + 4], res[i + 5]))
+            local_sum[3] = cute.arch.add_packed_f32x2(local_sum[3], (res[i + 6], res[i + 7]))
+        local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[1])
+        local_sum[2] = cute.arch.add_packed_f32x2(local_sum[2], local_sum[3])
+        local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[2])
+        return local_sum[0][0] + local_sum[0][1]
+
+
+@dsl_user_op
+def atomic_add_fp32(a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> None:
+    # gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    # # cache_hint = cutlass.Int64(0x12F0000000000000)
+    # llvm.inline_asm(
+    #     None,
+    #     [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip)],
+    #     # [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip), cache_hint.ir_value()],
+    #     "red.global.add.f32 [$0], $1;",
+    #     # "red.global.add.L2::cache_hint.f32 [$0], $1, 0x12F0000000000000;",
+    #     # "red.global.add.L2::cache_hint.f32 [$0], $1, $2;",
+    #     "l,f",
+    #     # "l,f,l",
+    #     has_side_effects=True,
+    #     is_align_stack=False,
+    #     asm_dialect=llvm.AsmDialect.AD_ATT,
+    # )
+    nvvm.atomicrmw(
+        res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=Float32(a).ir_value()
+    )
+
+
+@dsl_user_op
+def elem_pointer(x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    # Only compute predicates for the "k" dimension. For the mn dimension, we will use "if"
+    tApA = cute.make_fragment(
+        cute.make_layout(
+            (cute.size(tAcA, mode=[0, 1]), cute.size(tAcA, mode=[1]), cute.size(tAcA, mode=[2])),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(tAcA[(0, rest_v), 0, rest_k][1], limit)
+    return tApA
+
+
+def canonical_warp_group_idx(sync: bool = True) -> cutlass.Int32:
+    warp_group_idx = cute.arch.thread_idx()[0] // 128
+    if const_expr(sync):
+        warp_group_idx = cute.arch.make_warp_uniform(warp_group_idx)
+    return warp_group_idx
+
+
+# @dsl_user_op
+# def warp_vote_any_lt(a: float | Float32, b: float | Float32, *, loc=None, ip=None) -> cutlass.Boolean:
+#     mask = cutlass.Int32(-1)
+#     return cutlass.Boolean(
+#         llvm.inline_asm(
+#             T.i32(),
+#             [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip), mask.ir_value(loc=loc, ip=ip)],
+#             ".pred p1, p2;\n"
+#             "setp.lt.f32 p1, $1, $2;\n"
+#             "vote.sync.any.pred p2, p1, $3;\n"
+#             "selp.u32 $0, 1, 0, p2;",
+#             # "selp.u32 $0, 1, 0, p1;",
+#             "=r,f,f,r",
+#             has_side_effects=False,
+#             is_align_stack=False,
+#             asm_dialect=llvm.AsmDialect.AD_ATT,
+#         )
+#     )
+
+
+@cute.jit
+def shuffle_sync(
+    value: cute.Numeric,
+    offset: cute.typing.Int,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.Numeric:
+    assert value.width % 32 == 0, "value type must be a multiple of 32 bits"
+    # 1 -> 0b11111, 2 -> 0b11110, 4 -> 0b11100, 8 -> 0b11000, 16 -> 0b10000, 32 -> 0b00000
+    mask = cute.arch.WARP_SIZE - width
+    clamp = cute.arch.WARP_SIZE - 1
+    mask_and_clamp = mask << 8 | clamp
+    # important: need stride 1 and not 0 for recast_tensor to work
+    val = cute.make_rmem_tensor(cute.make_layout((1,), stride=(1,)), type(value))
+    val[0] = value
+    val_i32 = cute.recast_tensor(val, cutlass.Int32)
+    for i in cutlass.range_constexpr(cute.size(val_i32)):
+        val_i32[i] = cute.arch.shuffle_sync(val_i32[i], offset, mask_and_clamp=mask_and_clamp)
+    return val[0]
+
+
+@dsl_user_op
+def shl_u32(val: cutlass.Uint32, shift: cutlass.Uint32, *, loc=None, ip=None) -> cutlass.Uint32:
+    """
+    Left-shift val by shift bits using PTX shl.b32 (sign-agnostic).
+
+    Named ``shl_u32`` (not ``shl_b32``) because python type annotations
+    distinguish signed/unsigned.
+
+    PTX semantics (§9.7.8.8): "Shift amounts greater than the register width N
+    are clamped to N."  So ``shl.b32 d, a, 32`` is well-defined and yields 0.
+
+    This differs from C/C++ and LLVM IR, where shifting by >= the type width is
+    undefined behavior.  CuTeDSL compiles through MLIR -> LLVM IR, so a plain
+    Python-level ``Uint32(x) << Uint32(n)`` inherits LLVM's UB: the optimizer
+    may treat the result as poison and eliminate dependent code.  Inline PTX
+    bypasses the LLVM IR shift entirely — the instruction is emitted verbatim
+    into PTX where clamping makes it safe for all shift amounts.
+    """
+    return cutlass.Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                cutlass.Uint32(val).ir_value(loc=loc, ip=ip),
+                cutlass.Uint32(shift).ir_value(loc=loc, ip=ip),
+            ],
+            "shl.b32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def shr_u32(val: cutlass.Uint32, shift: cutlass.Uint32, *, loc=None, ip=None) -> cutlass.Uint32:
+    """
+    Unsigned right-shift val by shift bits using PTX shr.u32 (zero-fills).
+
+    See ``shl_u32`` docstring for why inline PTX is used instead of plain
+    CuTeDSL shift operators (LLVM shift-by-type-width UB).
+    """
+    return cutlass.Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                cutlass.Uint32(val).ir_value(loc=loc, ip=ip),
+                cutlass.Uint32(shift).ir_value(loc=loc, ip=ip),
+            ],
+            "shr.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def warp_prefix_sum(val: cutlass.Int32, lane: Optional[cutlass.Int32] = None) -> cutlass.Int32:
+    if const_expr(lane is None):
+        lane = cute.arch.lane_idx()
+    # if cute.arch.thread_idx()[0] >= 128 and cute.arch.thread_idx()[0] < 128 + 32 and cute.arch.block_idx()[0] == 0: cute.printf("tidx = %d, val = %d", cute.arch.thread_idx()[0] % 32, val)
+    for i in cutlass.range_constexpr(int(math.log2(cute.arch.WARP_SIZE))):
+        offset = 1 << i
+        # Very important that we set mask_and_clamp to 0
+        partial_sum = cute.arch.shuffle_sync_up(val, offset=offset, mask_and_clamp=0)
+        if lane >= offset:
+            val += partial_sum
+        # if cute.arch.thread_idx()[0] >= 128 and cute.arch.thread_idx()[0] < 128 + 32 and cute.arch.block_idx()[0] == 0: cute.printf("tidx = %d, partial_sum = %d, val = %d", cute.arch.thread_idx()[0] % 32, partial_sum, val)
+    return val
+
+
+@dsl_user_op
+def cvt_f16x2_f32(
+    a: float | Float32, b: float | Float32, to_dtype: Type, *, loc=None, ip=None
+) -> cutlass.Int32:
+    assert to_dtype in [cutlass.BFloat16, cutlass.Float16], "to_dtype must be BFloat16 or Float16"
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            f"cvt.rn.{'bf16x2' if to_dtype is cutlass.BFloat16 else 'f16x2'}.f32 $0, $2, $1;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@overload
+def cvt_f16(src: cute.Tensor, dst: cute.Tensor) -> None: ...
+
+
+@overload
+def cvt_f16(src: cute.Tensor, dtype: Type[cute.Numeric]) -> cute.Tensor: ...
+
+
+@cute.jit
+def cvt_f16(src: cute.Tensor, dst_or_dtype):
+    """Convert Float32 tensor to Float16/BFloat16.
+
+    Args:
+        src: Source tensor with Float32 element type
+        dst_or_dtype: Either a destination tensor or a dtype (Float16/BFloat16)
+
+    Returns:
+        None if dst is a tensor, or a new tensor if dtype is provided
+    """
+    if const_expr(isinstance(dst_or_dtype, type)):
+        # dtype variant: create new tensor and call the tensor variant
+        dtype = dst_or_dtype
+        dst = cute.make_fragment(src.shape, dtype)
+        cvt_f16(src, dst)
+        return dst
+    else:
+        # tensor variant: write to dst
+        dst = dst_or_dtype
+        assert cute.size(dst.shape) == cute.size(src.shape), "dst and src must have the same size"
+        assert cute.size(src.shape) % 2 == 0, "src must have an even number of elements"
+        assert dst.element_type in [cutlass.BFloat16, cutlass.Float16], (
+            "dst must be BFloat16 or Float16"
+        )
+        assert src.element_type is Float32, "src must be Float32"
+        dst_i32 = cute.recast_tensor(dst, cutlass.Int32)
+        assert cute.size(dst_i32.shape) * 2 == cute.size(src.shape)
+        for i in cutlass.range_constexpr(cute.size(dst_i32)):
+            dst_i32[i] = cvt_f16x2_f32(src[2 * i], src[2 * i + 1], dst.element_type)
+
+
+@dsl_user_op
+@cute.jit
+def evaluate_polynomial(x: Float32, poly: Tuple[Float32, ...], *, loc=None, ip=None) -> Float32:
+    deg = len(poly) - 1
+    out = poly[deg]
+    for i in cutlass.range_constexpr(deg - 1, -1, -1):
+        out = out * x + poly[i]
+    return out
+
+
+@dsl_user_op
+@cute.jit
+def evaluate_polynomial_2(
+    x: Float32, y: Float32, poly: Tuple[Float32, ...], *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    deg = len(poly) - 1
+    out = (poly[deg], poly[deg])
+    for i in cutlass.range_constexpr(deg - 1, -1, -1):
+        out = cute.arch.fma_packed_f32x2(out, (x, y), (poly[i], poly[i]))
+    return out
+
+
+@dsl_user_op
+def add_round_down(x: float | Float32, y: float | Float32, *, loc=None, ip=None) -> Float32:
+    # There's probably a way to call llvm or nvvm to do this instead of ptx
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(x).ir_value(loc=loc, ip=ip), Float32(y).ir_value(loc=loc, ip=ip)],
+            "add.rm.ftz.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def combine_int_frac_ex2(x_rounded: Float32, frac_ex2: Float32, *, loc=None, ip=None) -> Float32:
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Float32(x_rounded).ir_value(loc=loc, ip=ip),
+                Float32(frac_ex2).ir_value(loc=loc, ip=ip),
+            ],
+            "{\n\t"
+            ".reg .s32 x_rounded_i, frac_ex_i, x_rounded_e, out_i;\n\t"
+            "mov.b32 x_rounded_i, $1;\n\t"
+            "mov.b32 frac_ex_i, $2;\n\t"
+            "shl.b32 x_rounded_e, x_rounded_i, 23;\n\t"
+            # add.u32 generates IMAD instruction and add.s32 generates LEA instruction
+            # IMAD uses the FMA pipeline and LEA uses the ALU pipeline, afaik
+            "add.s32 out_i, x_rounded_e, frac_ex_i;\n\t"
+            "mov.b32 $0, out_i;\n\t"
+            "}\n",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ex2_emulation(x: Float32, *, poly_degree: int = 3, loc=None, ip=None) -> Float32:
+    assert poly_degree in POLY_EX2, f"Polynomial degree {poly_degree} not supported"
+    # We assume x <= 127.0
+    fp32_round_int = float(2**23 + 2**22)
+    x_clamped = cute.arch.fmax(x, -127.0)
+    # We want to round down here, so that the fractional part is in [0, 1)
+    x_rounded = add_round_down(x_clamped, fp32_round_int, loc=loc, ip=ip)
+    # The integer floor of x is now in the last 8 bits of x_rounded
+    # We assume the next 2 ops round to nearest even. The rounding mode is important.
+    x_rounded_back = x_rounded - fp32_round_int
+    x_frac = x_clamped - x_rounded_back
+    x_frac_ex2 = evaluate_polynomial(x_frac, POLY_EX2[poly_degree], loc=loc, ip=ip)
+    return combine_int_frac_ex2(x_rounded, x_frac_ex2, loc=loc, ip=ip)
+
+
+# TODO: check that the ex2_emulation_2 produces the same SASS as the ptx version
+@dsl_user_op
+def ex2_emulation_2(
+    x: Float32, y: Float32, *, poly_degree: int = 3, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    # We assume x <= 127.0 and y <= 127.0
+    fp32_round_int = float(2**23 + 2**22)
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+    # We want to round down here, so that the fractional part is in [0, 1)
+    xy_rounded = cute.arch.add_packed_f32x2(xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm")
+    # The integer floor of x & y are now in the last 8 bits of xy_rounded
+    # We want the next 2 ops to round to nearest even. The rounding mode is important.
+    xy_rounded_back = quack.activation.sub_packed_f32x2(
+        xy_rounded, (fp32_round_int, fp32_round_int)
+    )
+    xy_frac = quack.activation.sub_packed_f32x2(xy_clamped, xy_rounded_back)
+    xy_frac_ex2 = evaluate_polynomial_2(*xy_frac, POLY_EX2[poly_degree], loc=loc, ip=ip)
+    x_out = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0], loc=loc, ip=ip)
+    y_out = combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1], loc=loc, ip=ip)
+    return x_out, y_out
+
+
+@dsl_user_op
+def e2e_asm2(x: Float32, y: Float32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    out_f32x2 = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Float32(x).ir_value(loc=loc, ip=ip), Float32(y, loc=loc, ip=ip).ir_value()],
+        "{\n\t"
+        ".reg .f32 f1, f2, f3, f4, f5, f6, f7;\n\t"
+        ".reg .b64 l1, l2, l3, l4, l5, l6, l7, l8, l9, l10;\n\t"
+        ".reg .s32 r1, r2, r3, r4, r5, r6, r7, r8;\n\t"
+        "max.ftz.f32 f1, $2, 0fC2FE0000;\n\t"
+        "max.ftz.f32 f2, $3, 0fC2FE0000;\n\t"
+        "mov.b64 l1, {f1, f2};\n\t"
+        "mov.f32 f3, 0f4B400000;\n\t"
+        "mov.b64 l2, {f3, f3};\n\t"
+        "add.rm.ftz.f32x2 l7, l1, l2;\n\t"
+        "sub.rn.ftz.f32x2 l8, l7, l2;\n\t"
+        "sub.rn.ftz.f32x2 l9, l1, l8;\n\t"
+        "mov.f32 f7, 0f3D9DF09D;\n\t"
+        "mov.b64 l6, {f7, f7};\n\t"
+        "mov.f32 f6, 0f3E6906A4;\n\t"
+        "mov.b64 l5, {f6, f6};\n\t"
+        "mov.f32 f5, 0f3F31F519;\n\t"
+        "mov.b64 l4, {f5, f5};\n\t"
+        "mov.f32 f4, 0f3F800000;\n\t"
+        "mov.b64 l3, {f4, f4};\n\t"
+        "fma.rn.ftz.f32x2 l10, l9, l6, l5;\n\t"
+        "fma.rn.ftz.f32x2 l10, l10, l9, l4;\n\t"
+        "fma.rn.ftz.f32x2 l10, l10, l9, l3;\n\t"
+        "mov.b64 {r1, r2}, l7;\n\t"
+        "mov.b64 {r3, r4}, l10;\n\t"
+        "shl.b32 r5, r1, 23;\n\t"
+        "add.s32 r7, r5, r3;\n\t"
+        "shl.b32 r6, r2, 23;\n\t"
+        "add.s32 r8, r6, r4;\n\t"
+        "mov.b32 $0, r7;\n\t"
+        "mov.b32 $1, r8;\n\t"
+        "}\n",
+        "=r,=r,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    out0 = Float32(llvm.extractvalue(T.f32(), out_f32x2, [0], loc=loc, ip=ip))
+    out1 = Float32(llvm.extractvalue(T.f32(), out_f32x2, [1], loc=loc, ip=ip))
+    return out0, out1
+
+
+@dsl_user_op
+def domain_offset_aligned(
+    coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None
+) -> cute.Tensor:
+    assert isinstance(tensor.iterator, cute.Pointer)
+    # We assume that applying the offset does not change the pointer alignment
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        elem_pointer(tensor, coord).toint(),
+        tensor.memspace,
+        assumed_align=tensor.iterator.alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@dsl_user_op
+def warp_reduction(
+    val: cute.Numeric, op: Callable, *, threads_in_group: int = 32, loc=None, ip=None
+) -> cute.Numeric:
+    """Warp-wide reduction helper for a custom binary op."""
+    offset = threads_in_group // 2
+    while offset > 0:
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=offset, mask=-1, mask_and_clamp=31, loc=loc, ip=ip
+            ),
+        )
+        offset //= 2
+    return val
+
+
+warp_reduction_max = partial(
+    warp_reduction, op=lambda x, y: fmax(x, y) if isinstance(x, Float32) else max(x, y)
+)
+warp_reduction_sum = partial(warp_reduction, op=lambda x, y: x + y)  # noqa: FURB118
+
+
+@dsl_user_op
+def make_cotiled_copy(
+    atom: cute.CopyAtom, atom_layout_tv: cute.Layout, data_layout: cute.Layout, *, loc=None, ip=None
+) -> cute.TiledCopy:
+    """Compatibility wrapper for deprecated CuTeDSL `make_cotiled_copy`."""
+    assert cute.is_static(atom_layout_tv.type), "atom_layout_tv must be static"
+    assert cute.is_static(data_layout.type), "data_layout must be static"
+
+    inv_layout_ = cute.left_inverse(data_layout, loc=loc, ip=ip)
+    inv_data_layout = cute.make_layout(
+        (inv_layout_.shape, (1)), stride=(inv_layout_.stride, (0)), loc=loc, ip=ip
+    )
+    layout_tv_data = cute.composition(inv_data_layout, atom_layout_tv, loc=loc, ip=ip)
+
+    atom_layout_v_to_check = cute.coalesce(
+        cute.make_layout(atom_layout_tv.shape[1], stride=atom_layout_tv.stride[1], loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    data_layout_v_to_check = cute.coalesce(
+        cute.composition(
+            data_layout,
+            cute.make_layout(
+                layout_tv_data.shape[1], stride=layout_tv_data.stride[1], loc=loc, ip=ip
+            ),
+            loc=loc,
+            ip=ip,
+        ),
+        loc=loc,
+        ip=ip,
+    )
+    assert data_layout_v_to_check == atom_layout_v_to_check, (
+        "the memory pointed to by atom_layout_tv does not exist in the data_layout."
+    )
+
+    flat_data_shape = cute.product_each(data_layout.shape, loc=loc, ip=ip)
+    tiler = tuple(
+        cute.filter(
+            cute.composition(
+                cute.make_layout(
+                    flat_data_shape,
+                    stride=tuple(0 if j != i else 1 for j in range(cute.rank(flat_data_shape))),
+                    loc=loc,
+                    ip=ip,
+                ),
+                layout_tv_data,
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+        for i in range(cute.rank(flat_data_shape))
+    )
+    tile2data = cute.composition(
+        cute.make_layout(flat_data_shape, loc=loc, ip=ip), tiler, loc=loc, ip=ip
+    )
+    layout_tv = cute.composition(
+        cute.left_inverse(tile2data, loc=loc, ip=ip), layout_tv_data, loc=loc, ip=ip
+    )
+    return cute.make_tiled_copy(atom, layout_tv, tiler, loc=loc, ip=ip)
+
+
+@cute.jit
+def scalar_to_ssa(a: cute.Numeric, dtype) -> cute.TensorSSA:
+    """Convert a scalar to a cute TensorSSA of shape (1,) and given dtype"""
+    vec = cute.make_fragment(1, dtype)
+    vec[0] = a
+    return vec.load()
+
+
+def ssa_to_scalar(val):
+    """Could inline but nice for reflecting the above api"""
+    return val[0]
+
+
+@cute.jit
+def get_batch_from_cu_tensor(idx: Int32, cu_tensor: cute.Tensor) -> Int32:
+    """Binary search to determine batch from packed index in a cumulative tensor"""
+    batch_size = cute.size(cu_tensor) - 1
+    lo = Int32(0)
+    hi = batch_size
+
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if cu_tensor[mid + 1] <= idx:
+            lo = mid + 1
+        else:
+            hi = mid
+
+    return lo

--- a/thrmma_shim.py
+++ b/thrmma_shim.py
@@ -1,0 +1,9 @@
+# --- compat shim (appended): re-export classes relocated in cutlass-dsl 4.6.0 ---
+# 4.5.x exposed ThrMma/TiledMma/ThrCopy/TiledCopy under cutlass.cute.core; 4.6.0 moved
+# them to the cutlass.cute top level. Lazy module __getattr__ (PEP 562) avoids any
+# circular-import hazard during package init.
+def __getattr__(name):
+    if name in ("ThrMma", "TiledMma", "ThrCopy", "TiledCopy"):
+        import cutlass.cute as _cute
+        return getattr(_cute, name)
+    raise AttributeError(f"module 'cutlass.cute.core' has no attribute {name!r}")


### PR DESCRIPTION
## What

A patch-layer Dockerfile (`Dockerfile.deepseek-v4-gb10-layer`, following the `Dockerfile.pr41703-layer` pattern) + three sm12x-gated `.py` overlays that make the stock `aeon-vllm-ultimate:2026-07-01-v0.24.0` image serve **DeepSeek-V4-Flash across 2× DGX Spark (TP2 + expert-parallel over RoCE)**. Full recipe + validation in `README-DEEPSEEK-V4-GB10.md`.

## Why

The 0.24 base already ships the native `vllm/models/deepseek_v4` package, but on GB10 it cannot even load — and behind that first failure is a cascade of five distinct gaps. Two of them affect **any** GPU, not just GB10:

1. **The image's own DeepSeek-V4 cutedsl ops are broken by its cutlass-dsl:** the image ships `nvidia-cutlass-dsl 4.6.0`, which removed `cute.core.ThrMma`, still referenced by `deepseek_v4/nvidia/ops/fused_indexer_q_cutedsl.py` → `AttributeError` on any DeepSeek-V4 load. **Fix:** pin 4.5.2.
2. **`flashinfer_sparse.py` targets the flashinfer 0.6.14 sparse-MLA API** (`swa_topk_lens`, `extra_sparse_*`) but the image ships 0.6.12 → `unexpected keyword argument`. **Fix:** upgrade the flashinfer trio to 0.6.14.
3. The vendored DeepGEMM is sm90/sm100-only (`Unsupported architecture` in `hyperconnection.hpp` / `attention.hpp` / einsum). **Fix:** install DeepGEMM `nv_dev` @ `a6b593d` ([deepseek-ai/DeepGEMM#324](https://github.com/deepseek-ai/DeepGEMM/pull/324), native sm120 kernels) — site-packages takes precedence over the vendored copy.
4. Three sm12x-only runtime gaps, fixed by thin overlays (no behavior change on sm90/100): the o_proj passes SM100 packed-ue8m0 scales/2-D weights that nv_dev's `fp8_einsum` rejects (adapter unpacks to fp32 scales + 3-D weights); `cooperative_topk`'s cluster launch fails on GB10 (`invalid argument` — routed to the existing `persistent_topk`); the triton block-scaled MM has no `float8_e8m0fnu` mapping (exact e8m0→fp32 upcast).
5. Serve-config requirements documented in the README: `VLLM_DEEP_GEMM_WARMUP=skip` (the linear warmup feeds raw e8m0 scales to `fp8_gemm_nt`), and `--enforce-eager --max-num-seqs 2` (see Known issue).

## Validation (2× DGX Spark, `DeepSeek-V4-Flash-DSpark` fp8, TP2/EP over RoCE)

- Layer builds from this branch as-is; overlay smoke test in the Dockerfile.
- **Full 12-category multi-turn benchmark: 48/48 turns completed, zero engine errors.**
- 17.8 tok/s single-stream (TTFT ~2.8 s), 28.6 tok/s aggregate over 10 concurrent multi-turn conversations; KV cache 782,838 tokens at util 0.80; engine init 58 s warm.
- Output quality graded at **parity with the independent jasl-fork GB10 build** (vLLM PR #41834 lineage) on the same checkpoint; temp-0 arithmetic/factual probes consistent between the two builds; no garbling.
- Stress: 2×10 concurrent 1500-token generations, 20/20 OK.

## Known issue (documented in the README)

Batched long-context decode (batch >2, contexts past a few thousand tokens) wedges the engine under **every** cudagraph mode (FULL, PIECEWISE, and the auto-enabled breakable-cudagraph): workers go silent, `sample_tokens` times out, engine dies. `VLLM_USE_BREAKABLE_CUDAGRAPH=0` extends survival ~6×; `--enforce-eager --max-num-seqs 2` is fully stable (the benchmark above). Suspect is the sparse-MLA decode path (nv_dev paged-MQA / `persistent_topk` / flashinfer trtllm sparse) at batch>2 with long contexts — I kept the diagnostic trail in the README in case you want to chase the kernel-level fix.

Happy to adjust layout/naming to your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)