### PR TITLE
Enable flashinfer_b12x MoE: bump apache-tvm-ffi 0.1.9 -> 0.1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,20 @@ RUN pip install --no-cache-dir \
     (flashinfer download-cubin 2>&1 | tail -3 || echo "[WARN] cubin download failed; runtime fallback") && \
     python3 -c "import flashinfer; print('flashinfer:', flashinfer.__version__)"
 
+# apache-tvm-ffi >= 0.1.10 is REQUIRED for the flashinfer_b12x CuteDSL MoE kernel on GB10.
+# nvidia-cutlass-dsl 4.6.0 (SM12x JIT) calls tvm_ffi ...make_kwargs_wrapper(map_dataclass_to_tuple=...),
+# a parameter added in tvm-ffi 0.1.10. The base image ships 0.1.9, so --moe-backend flashinfer_b12x
+# loads the model but CRASHES at the warmup forward pass with:
+#   TypeError: make_kwargs_wrapper() got an unexpected keyword argument 'map_dataclass_to_tuple'
+#   (flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py -> tvm_ffi.utils.kwargs_wrapper)
+# The FlashInfer 0.6.12 bump above enabled the b12x symbols but left tvm-ffi under-pinned; this pairs it.
+# Verified on GB10 (sm_121a): with 0.1.12, `--moe-backend flashinfer_b12x` boots to /health and serves.
+RUN pip install --no-cache-dir "apache-tvm-ffi==0.1.12" 2>&1 | tail -2 && \
+    python3 -c "import inspect, tvm_ffi, tvm_ffi.utils.kwargs_wrapper as k; \
+assert 'map_dataclass_to_tuple' in str(inspect.signature(k.make_kwargs_wrapper)), \
+'apache-tvm-ffi too old for flashinfer_b12x CuteDSL MoE'; \
+print('apache-tvm-ffi:', tvm_ffi.__version__, '(b12x kwargs_wrapper OK)')"
+
 # xgrammar >= 0.2.1 (v0.24.0 floor; base image ships older — tool-choice requests
 # 500 with ImportError: normalize_tool_choice without this. Found in prod 2026-07-02.)
 RUN pip install --no-cache-dir "xgrammar>=0.2.1,<1.0.0" 2>&1 | tail -2 && \


### PR DESCRIPTION
## Enable `flashinfer_b12x` MoE on GB10: pin `apache-tvm-ffi==0.1.12`

### Problem
`--moe-backend flashinfer_b12x` — the SM12x (GB10 / DGX Spark) native FP4 fused-MoE kernel — is advertised in the image (`KernelConfig` help + `ai.aeon.vllm_features=…,flashinfer-b12x,…`) but **crashes at the warmup forward pass**. The model loads and the backend is selected (`Using 'FLASHINFER_B12X' NvFp4 MoE backend`), then the first CuteDSL kernel compile dies with:

```
TypeError: make_kwargs_wrapper() got an unexpected keyword argument 'map_dataclass_to_tuple'
  flashinfer/fused_moe/cute_dsl/b12x_moe.py -> blackwell_sm12x/moe_dispatch.py
    -> nvidia_cutlass_dsl ... -> tvm_ffi.utils.kwargs_wrapper.make_kwargs_wrapper(...)
```

Reproduced on both `2026-07-01-v0.24.0` and `2026-07-08-v0.24.0-maxsafe`.

### Root cause
A dependency version skew baked into the image:
- `nvidia-cutlass-dsl 4.6.0` (the SM12x CuteDSL JIT) calls `tvm_ffi.utils.kwargs_wrapper.make_kwargs_wrapper(map_dataclass_to_tuple=…)`.
- That parameter was **added in `apache-tvm-ffi 0.1.10`**; the base image ships **`0.1.9`**.

The Dockerfile already bumps FlashInfer `0.6.8.post1 → 0.6.12` specifically to expose the b12x symbols, but the companion `apache-tvm-ffi` bump was missed, so the kernel is present-but-unrunnable. (The pip resolver also flags the image's `nvidia-cutlass-dsl 4.6.0` vs the vLLM wheel's `==4.5.2` request — related pin drift.)

### Fix
One `RUN` after the FlashInfer block pins `apache-tvm-ffi==0.1.12` (0.1.10 is the floor; 0.1.12 is latest and matches cutlass-dsl 4.6.0's full API), plus a build-time signature assert so this regression is caught at build:

```dockerfile
RUN pip install --no-cache-dir "apache-tvm-ffi==0.1.12" && \
    python3 -c "import inspect, tvm_ffi, tvm_ffi.utils.kwargs_wrapper as k; \
assert 'map_dataclass_to_tuple' in str(inspect.signature(k.make_kwargs_wrapper)); \
print('apache-tvm-ffi:', tvm_ffi.__version__)"
```

### Verification (GB10 / sm_121a, Qwen3.6-35B-A3B NVFP4 + MTP n=3, fp8 KV)
- Before: EngineCore exits (1) during warmup (traceback above).
- After: `--moe-backend flashinfer_b12x` boots to `/health` and serves; CUDA-graph capture completes; smoke + tool-call OK.
- Perf note: b12x improves **prefill** materially (PP2048 ≈ 2220 → 2530 tok/s on nvidia weights; ≈ 3180 tok/s on the all-FP4 `unsloth/…-NVFP4-Fast`). Single-stream TG is unchanged/slightly lower (memory-bandwidth bound at batch≈1), i.e. b12x's win is prefill/high-concurrency — but it no longer crashes, so the backend is usable.

No other files touched.